### PR TITLE
combat-stance: directional locomotion + 150ms cross-fade blends

### DIFF
--- a/ffxi-client/src/view_native/mod.rs
+++ b/ffxi-client/src/view_native/mod.rs
@@ -520,6 +520,8 @@ fn despawn_ingame_entities(
     mut system_sfx_cursor: ResMut<ffxi_viewer_core::audio::SystemSfxCursor>,
     mut engagement_chat_cursor: ResMut<ffxi_viewer_core::debug_chat::EngagementChatCursor>,
     mut speed_suppression_latch: ResMut<ffxi_viewer_core::debug_chat::SpeedSuppressionLatch>,
+    mut entity_motion: ResMut<ffxi_viewer_core::combat_stance::EntityMotion>,
+    mut animation_blends: ResMut<ffxi_viewer_core::combat_stance::AnimationBlends>,
 ) {
     let mut count = 0usize;
     for entity in q.iter() {
@@ -581,6 +583,15 @@ fn despawn_ingame_entities(
     // session's first snapshot lands.
     *scene = SceneState::default();
     events.recent.clear();
+    // Locomotion caches: both are keyed by wire entity id, and
+    // ids are session-scoped (the next session may reuse the same
+    // id for a totally different actor). Without draining, the new
+    // session's first frame would read a stale `last_pos` /
+    // `from_clip` and either emit a giant speed spike (snap) or
+    // cross-fade from an unrelated anim. Drain on InGame exit so
+    // each session starts with a clean per-actor history.
+    entity_motion.by_id.clear();
+    animation_blends.by_id.clear();
 
     tracing::info!(count, "OnExit(InGame): despawned scoped entities");
 }

--- a/ffxi-viewer-core/src/combat_stance.rs
+++ b/ffxi-viewer-core/src/combat_stance.rs
@@ -45,6 +45,7 @@ use ffxi_dat::anim::Mo2Animation;
 use ffxi_dat::{walk, ChunkKind, DatRoot};
 
 use crate::components::WorldEntity;
+use crate::snapshot::SceneState;
 
 /// Reverse-map a PC skeleton DAT id to its motion DAT id (battle
 /// animation set #0 — unarmed).
@@ -87,6 +88,28 @@ static RUN_ANIMS: OnceLock<Mutex<HashMap<u32, Option<Arc<Mo2Animation>>>>> = Onc
 /// 68-bone full rig). PC-only; keyed by motion DAT id like
 /// [`BATTLE_IDLE_ANIMS`].
 static COMBAT_RUN_ANIMS: OnceLock<Mutex<HashMap<u32, Option<Arc<Mo2Animation>>>>> =
+    OnceLock::new();
+
+/// Cache for directional locomotion variants resolved by 3-char prefix
+/// against the skeleton DAT. Key is `(skel_file_id, prefix)`.
+///
+/// Probed prefixes (see [`directional_anim_for_skel`]):
+///   - `bck` — backpedal. Absent from every PC skeleton DAT we probed;
+///     callers fall back to `run` at negative time-scale.
+///   - `stl` / `str` — strafe-left / strafe-right. Absent from PC
+///     skeletons; retail does *not* ship strafe clips and the engine
+///     just plays `run` while the camera-relative input picks the
+///     direction. We probe them anyway in case beastman/NPC skels
+///     carry them; if they don't, the cached `None` makes lookups O(1).
+///   - `trn` — turn-in-place. Absent from PC skeletons; retail uses
+///     the idle pose with a yaw-only delta. Probed for NPC skeletons
+///     that may carry it (some ranger NPCs do).
+///   - `wlk` — walk. Present on most PC skeletons as `wlk0`; used
+///     for sub-base-run speeds (e.g. shadow walk, /walk toggle).
+///
+/// Cache entries are keyed by `(file_id, [u8; 3])` rather than a
+/// string so we don't pay a `String` allocation per query.
+static DIRECTIONAL_ANIMS: OnceLock<Mutex<HashMap<(u32, [u8; 3]), Option<Arc<Mo2Animation>>>>> =
     OnceLock::new();
 
 /// 3-char MO2 name prefix for the battle-idle pose inside a motion
@@ -162,6 +185,21 @@ pub fn combat_run_anim_for_skel(skel_file_id: u32) -> Option<Arc<Mo2Animation>> 
     loaded
 }
 
+/// Resolve a directional locomotion variant (`bck`/`stl`/`str`/`trn`/`wlk`)
+/// from a skeleton DAT. Cached; returns `None` and caches that `None`
+/// if the DAT carries no chunk with that 3-char prefix.
+pub fn directional_anim_for_skel(skel_file_id: u32, prefix: &[u8; 3]) -> Option<Arc<Mo2Animation>> {
+    let map = DIRECTIONAL_ANIMS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard = map.lock().ok()?;
+    let key = (skel_file_id, *prefix);
+    if let Some(entry) = guard.get(&key) {
+        return entry.clone();
+    }
+    let loaded = load_anim_with_prefix(skel_file_id, prefix).map(Arc::new);
+    guard.insert(key, loaded.clone());
+    loaded
+}
+
 /// Shared loader: open a DAT, walk its chunks, return the first MO2
 /// whose 3-char name prefix matches `prefix`. Used for `btl`, `run`,
 /// and any future prefix we wire up (`wlk`, `mvb`, …).
@@ -183,6 +221,105 @@ fn load_anim_with_prefix(file_id: u32, prefix: &[u8; 3]) -> Option<Mo2Animation>
     None
 }
 
+/// A logical animation slot picked by `tick_skinned_actors` for a
+/// given (engaged, motion-pattern) tuple. Used both as a key for
+/// detecting "the clip changed since last frame" and as the
+/// `from`/`to` ends of a [`AnimationBlend`].
+///
+/// We deliberately do NOT use `Arc<Mo2Animation>` pointer identity
+/// — the per-skel caches hand back the same `Arc` for repeated
+/// queries of the same slot, but multiple distinct
+/// `(skel, prefix)` combos may resolve to the same underlying clip
+/// when a race lacks a dedicated variant and falls back to e.g.
+/// `run`. Comparing by `ClipId` matches the *intent* (what the
+/// selection rule chose) rather than the resolved bytes.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum ClipId {
+    Idle,
+    BattleIdle,
+    Run,
+    CombatRun,
+    /// Backpedal — currently always resolves to `Run` played at
+    /// negative time-scale (no `bck` clip exists on PC skeletons we
+    /// probed). Carried as a distinct ClipId so the cross-fade trips
+    /// when transitioning between run and backpedal.
+    Backpedal,
+    /// Strafe left / right — falls back to `Run` when the
+    /// per-skeleton `stl`/`str` probe returns `None`.
+    StrafeLeft,
+    StrafeRight,
+    /// Turn-in-place — falls back to `Idle` when no `trn` clip.
+    TurnInPlace,
+    /// Walk speed (sub-base-run). Falls back to `Run` when no `wlk`.
+    Walk,
+}
+
+/// Per-actor cross-fade state. Stored in a `Resource` keyed by wire
+/// entity id (parallel to [`EntityMotion`]) rather than as an ECS
+/// `Component` so the lifetime is dictated by gameplay (clear when
+/// the entity vanishes from the snapshot) rather than ECS spawn /
+/// despawn churn.
+#[derive(Clone, Copy, Debug)]
+pub struct AnimationBlend {
+    pub from_clip: ClipId,
+    pub to_clip: ClipId,
+    /// Blend progress in [0, 1]. 0 = fully on `from`, 1 = fully
+    /// settled on `to`.
+    pub t: f32,
+    /// Total duration in seconds for this cross-fade. 0.15 is the
+    /// retail-feel default — long enough to hide popping, short
+    /// enough that fast direction changes still feel responsive.
+    pub duration: f32,
+}
+
+/// Per-actor cross-fade table. See [`AnimationBlend`].
+#[derive(Resource, Default)]
+pub struct AnimationBlends {
+    pub by_id: HashMap<u32, AnimationBlend>,
+}
+
+impl AnimationBlends {
+    pub const DEFAULT_DURATION: f32 = 0.15;
+
+    /// Start a cross-fade from the entity's last-selected clip to
+    /// `to`. If there is no last clip (first frame the entity is
+    /// seen) or the entity is already on `to`, sets the blend
+    /// directly to t=1.0 / no-op respectively. Call once per frame
+    /// per actor.
+    pub fn update(&mut self, id: u32, current: ClipId, dt: f32) {
+        match self.by_id.get_mut(&id) {
+            None => {
+                self.by_id.insert(
+                    id,
+                    AnimationBlend {
+                        from_clip: current,
+                        to_clip: current,
+                        t: 1.0,
+                        duration: Self::DEFAULT_DURATION,
+                    },
+                );
+            }
+            Some(blend) => {
+                if blend.to_clip != current {
+                    // Mid-blend retarget: pin the visual position by
+                    // treating the current interpolated state as the
+                    // new `from`. We approximate by setting from =
+                    // previous to and resetting t — the visual jump
+                    // is sub-frame because the blend was already
+                    // most of the way through the previous transition
+                    // in nearly every realistic case.
+                    blend.from_clip = blend.to_clip;
+                    blend.to_clip = current;
+                    blend.t = 0.0;
+                    blend.duration = Self::DEFAULT_DURATION;
+                } else if blend.t < 1.0 {
+                    blend.t = (blend.t + dt / blend.duration.max(1e-4)).min(1.0);
+                }
+            }
+        }
+    }
+}
+
 /// Per-entity motion state: last seen Bevy translation and the
 /// computed velocity magnitude from the previous frame.
 ///
@@ -200,12 +337,35 @@ fn load_anim_with_prefix(file_id: u32, prefix: &[u8; 3]) -> Option<Mo2Animation>
 /// practice the wrong-sign bug went the *other* way: the engaged
 /// path was never reached because the snapshot doesn't echo
 /// post-LOGIN speed changes consistently.
+/// Per-entity directional motion sample.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct MotionSample {
+    /// Last observed Bevy translation. Used to derive next-frame
+    /// velocity by finite difference.
+    pub last_pos: Vec3,
+    /// xz speed magnitude in yalms/sec.
+    pub speed: f32,
+    /// Velocity projected onto the entity's facing direction (xz). +
+    /// = forward, − = backpedal. Magnitude is yalms/sec.
+    pub forward_component: f32,
+    /// Velocity projected perpendicular to facing. + = right (strafe-R),
+    /// − = left (strafe-L). Right is defined as a 90° CW rotation of
+    /// forward in the xz-plane (FFXI heading convention).
+    pub strafe_component: f32,
+    /// Last observed heading (u8 LSB convention). Stored as the
+    /// unwrapped float in radians so cross-zero wraps don't generate
+    /// spurious "instant 360° spin" rate spikes.
+    pub last_heading_rad: f32,
+    /// Heading rotation rate in rad/sec, unwrapped across the
+    /// 0/2π seam. Sign matches FFXI heading: + = clockwise from
+    /// above (per scene::heading_to_quat docstring).
+    pub heading_rate: f32,
+}
+
 #[derive(Resource, Default)]
 pub struct EntityMotion {
-    /// `(last_translation, current_speed_yalms_per_sec)` per wire
-    /// entity id. Speed is the magnitude of last frame's xz delta
-    /// divided by `Time::delta_secs()`.
-    pub by_id: HashMap<u32, (Vec3, f32)>,
+    /// Per-wire-entity motion sample. See [`MotionSample`].
+    pub by_id: HashMap<u32, MotionSample>,
 }
 
 impl EntityMotion {
@@ -215,14 +375,21 @@ impl EntityMotion {
     /// missing actual locomotion. FFXI base run speed is ~5
     /// yalms/sec, so 0.5 is well below the genuine-motion floor.
     pub fn is_moving(&self, id: u32) -> bool {
-        self.by_id.get(&id).is_some_and(|(_, v)| *v > Self::MOVE_THRESHOLD)
+        self.by_id
+            .get(&id)
+            .is_some_and(|s| s.speed > Self::MOVE_THRESHOLD)
     }
 
-    /// Minimum xz speed in yalms/sec to count as "moving". Above
-    /// the smoothing noise floor (`SNAP_DIST_SQ.sqrt() * VISUAL_SMOOTH
-    /// / dt` for a 60 Hz tick is ~0.6 yalms/sec at the extreme; 0.5
-    /// catches everything but a stop-and-go jitter sequence).
-    const MOVE_THRESHOLD: f32 = 0.5;
+    /// Lookup the full sample. Returns `None` for never-seen ids.
+    pub fn sample(&self, id: u32) -> Option<MotionSample> {
+        self.by_id.get(&id).copied()
+    }
+
+    /// Minimum xz speed in yalms/sec to count as "moving".
+    pub const MOVE_THRESHOLD: f32 = 0.5;
+    /// Minimum |heading_rate| in rad/sec to count as "turning in place".
+    /// ~28°/sec — above sample noise, well below combat-cam yaw flicks.
+    pub const TURN_THRESHOLD_RAD_PER_SEC: f32 = 0.5;
 }
 
 /// Per-frame: write each `WorldEntity`'s current xz speed into
@@ -231,20 +398,71 @@ impl EntityMotion {
 /// the same-frame motion state.
 pub fn track_entity_motion_system(
     time: Res<Time>,
+    state: Res<SceneState>,
     mut motion: ResMut<EntityMotion>,
     q: Query<(&WorldEntity, &Transform)>,
 ) {
     let dt = time.delta_secs().max(1e-4);
     for (world, transform) in &q {
         let pos = transform.translation;
-        let entry = motion.by_id.entry(world.id).or_insert((pos, 0.0));
-        let dx = pos.x - entry.0.x;
-        let dz = pos.z - entry.0.z;
-        let xz_dist = (dx * dx + dz * dz).sqrt();
-        // Y is ignored deliberately: terrain/floor snap can shift
-        // y per-frame without the entity actually moving.
-        entry.0 = pos;
-        entry.1 = xz_dist / dt;
+        // Convert wire heading (u8, 0..256) to radians using LSB
+        // convention echoed in `scene::heading_to_quat`: heading 0 =
+        // +Y in FFXI = -Z in Bevy. We compute the forward vector
+        // *directly in Bevy xz* so projection math stays consistent
+        // with the Transform we read above.
+        let heading_u8 = state
+            .snapshot
+            .entities
+            .iter()
+            .find(|e| e.id == world.id)
+            .map(|e| e.heading)
+            .unwrap_or(0);
+        let heading_rad =
+            (heading_u8 as f32) * std::f32::consts::TAU / 256.0;
+        // Forward in Bevy xz: heading 0 → (-Z). `Quat::from_rotation_y(-θ)`
+        // applied to default forward (0, 0, -1) gives
+        // (-sin(-θ), 0, -cos(-θ)) = (sin θ, 0, -cos θ).
+        let fwd_x = heading_rad.sin();
+        let fwd_z = -heading_rad.cos();
+        // Right vector = 90° CW from forward in xz-plane (looking
+        // down +Y). CW rotation of (x, z) by 90° is (z, -x).
+        let right_x = fwd_z;
+        let right_z = -fwd_x;
+
+        let prev = motion.by_id.get(&world.id).copied().unwrap_or(MotionSample {
+            last_pos: pos,
+            last_heading_rad: heading_rad,
+            ..Default::default()
+        });
+        let dx = pos.x - prev.last_pos.x;
+        let dz = pos.z - prev.last_pos.z;
+        let vx = dx / dt;
+        let vz = dz / dt;
+        let speed = (vx * vx + vz * vz).sqrt();
+        let forward_component = vx * fwd_x + vz * fwd_z;
+        let strafe_component = vx * right_x + vz * right_z;
+
+        // Heading rate: unwrap across the 0/2π seam so wrapping from
+        // 255 → 0 doesn't read as a ~2π/dt instant spin spike.
+        let mut dh = heading_rad - prev.last_heading_rad;
+        if dh > std::f32::consts::PI {
+            dh -= std::f32::consts::TAU;
+        } else if dh < -std::f32::consts::PI {
+            dh += std::f32::consts::TAU;
+        }
+        let heading_rate = dh / dt;
+
+        motion.by_id.insert(
+            world.id,
+            MotionSample {
+                last_pos: pos,
+                speed,
+                forward_component,
+                strafe_component,
+                last_heading_rad: heading_rad,
+                heading_rate,
+            },
+        );
     }
 }
 
@@ -350,10 +568,15 @@ mod tests {
     #[test]
     fn is_moving_threshold_behaviour() {
         let mut m = EntityMotion::default();
-        m.by_id.insert(1, (Vec3::ZERO, 0.0));
-        m.by_id.insert(2, (Vec3::ZERO, 0.49));
-        m.by_id.insert(3, (Vec3::ZERO, 0.51));
-        m.by_id.insert(4, (Vec3::ZERO, 6.0));
+        let make = |speed: f32| MotionSample {
+            last_pos: Vec3::ZERO,
+            speed,
+            ..Default::default()
+        };
+        m.by_id.insert(1, make(0.0));
+        m.by_id.insert(2, make(0.49));
+        m.by_id.insert(3, make(0.51));
+        m.by_id.insert(4, make(6.0));
         assert!(!m.is_moving(1), "0 speed should not animate");
         assert!(!m.is_moving(2), "below 0.5 should not animate");
         assert!(m.is_moving(3), "just above 0.5 should animate");

--- a/ffxi-viewer-core/src/dat_vos2.rs
+++ b/ffxi-viewer-core/src/dat_vos2.rs
@@ -1639,10 +1639,13 @@ pub fn tick_skinned_actors(
     time: Res<Time>,
     state: Res<crate::snapshot::SceneState>,
     motion: Res<crate::combat_stance::EntityMotion>,
+    mut blends: ResMut<crate::combat_stance::AnimationBlends>,
     q_actors: Query<(&crate::components::WorldEntity, &SkinnedActor)>,
     mut q_bones: Query<&mut Transform>,
 ) {
+    use crate::combat_stance::{ClipId, EntityMotion};
     let elapsed = time.elapsed_secs();
+    let dt = time.delta_secs();
     for (world, actor) in &q_actors {
         let Some(baked) = baked_skeleton_for_file(actor.dat_id) else {
             continue;
@@ -1662,32 +1665,137 @@ pub fn tick_skinned_actors(
             .find(|e| e.id == world.id)
             .map(|e| e.bt_target_id != 0)
             .unwrap_or(false);
-        let moving = motion.is_moving(world.id);
+        let sample = motion
+            .sample(world.id)
+            .unwrap_or(crate::combat_stance::MotionSample::default());
+        let moving = sample.speed > EntityMotion::MOVE_THRESHOLD;
 
-        // Pick the right anim per the (engaged, moving) matrix in
-        // the doc comment above. Each `or_else` is a graceful
-        // degradation step — NPC skels lack motion DATs, some NPC
-        // skels lack `run` entirely, so the chain always ends with
-        // the universally-present `idl`.
-        let anim = match (engaged, moving) {
-            (true, true) => crate::combat_stance::combat_run_anim_for_skel(actor.dat_id)
-                .or_else(|| crate::combat_stance::run_anim_for_skel(actor.dat_id))
-                .or_else(|| crate::combat_stance::battle_idle_anim_for_skel(actor.dat_id))
-                .or_else(|| idle_anim_for_file(actor.dat_id)),
-            (true, false) => crate::combat_stance::battle_idle_anim_for_skel(actor.dat_id)
-                .or_else(|| idle_anim_for_file(actor.dat_id)),
-            (false, true) => crate::combat_stance::run_anim_for_skel(actor.dat_id)
-                .or_else(|| idle_anim_for_file(actor.dat_id)),
-            (false, false) => idle_anim_for_file(actor.dat_id),
+        // Pick a logical ClipId. The directional rule (strafe /
+        // backpedal / turn-in-place) only applies to the casual,
+        // non-engaged locomotion path; the engaged path keeps the
+        // simpler (engaged, moving) matrix because retail combat
+        // stance has no strafe variants — combat run with a yawed
+        // root looks the same in every horizontal direction.
+        //
+        // Magnitude threshold for the strafe-vs-forward decision is
+        // half the run threshold — both components must be non-trivial
+        // *and* the strafe component must dominate.
+        let dir_threshold = EntityMotion::MOVE_THRESHOLD * 0.5;
+        let clip_id = if engaged {
+            if moving { ClipId::CombatRun } else { ClipId::BattleIdle }
+        } else if moving {
+            let fwd = sample.forward_component;
+            let strafe = sample.strafe_component;
+            if strafe.abs() > fwd.abs()
+                && strafe.abs() > dir_threshold
+                && fwd.abs() > dir_threshold * 0.5
+            {
+                if strafe > 0.0 { ClipId::StrafeRight } else { ClipId::StrafeLeft }
+            } else if fwd < -dir_threshold {
+                ClipId::Backpedal
+            } else {
+                ClipId::Run
+            }
+        } else if sample.heading_rate.abs() > EntityMotion::TURN_THRESHOLD_RAD_PER_SEC {
+            ClipId::TurnInPlace
+        } else {
+            ClipId::Idle
         };
-        let Some(anim) = anim else {
+
+        // Resolve a ClipId to (anim, time_scale_signum). Each step is
+        // a graceful degradation — NPC skels lack motion DATs, no PC
+        // skel ships a `bck`/`stl`/`str`/`trn` clip (probed empty), so
+        // the chain always ends on something universally present.
+        //
+        // INLINE NOTE: empirically the following 3-char prefixes are
+        // ABSENT from every retail PC skeleton DAT and motion DAT we
+        // could probe:
+        //   - `bck` (backpedal)  — fall back to `run` at -1× time scale
+        //   - `stl` / `str` (strafe L/R) — fall back to `run` (no sign flip)
+        //   - `trn` (turn-in-place)      — fall back to `idl`
+        // Walk (`wlk`) IS present on most PC skel DATs. The probe is
+        // still in `directional_anim_for_skel` so that beastman / NPC
+        // skels carrying these clips (if any) light up automatically.
+        let resolve = |clip: ClipId| -> Option<(std::sync::Arc<ffxi_dat::anim::Mo2Animation>, f32)> {
+            match clip {
+                ClipId::CombatRun => crate::combat_stance::combat_run_anim_for_skel(actor.dat_id)
+                    .or_else(|| crate::combat_stance::run_anim_for_skel(actor.dat_id))
+                    .or_else(|| crate::combat_stance::battle_idle_anim_for_skel(actor.dat_id))
+                    .or_else(|| idle_anim_for_file(actor.dat_id))
+                    .map(|a| (a, 1.0)),
+                ClipId::BattleIdle => crate::combat_stance::battle_idle_anim_for_skel(actor.dat_id)
+                    .or_else(|| idle_anim_for_file(actor.dat_id))
+                    .map(|a| (a, 1.0)),
+                ClipId::Run => crate::combat_stance::run_anim_for_skel(actor.dat_id)
+                    .or_else(|| idle_anim_for_file(actor.dat_id))
+                    .map(|a| (a, 1.0)),
+                ClipId::Backpedal => crate::combat_stance::directional_anim_for_skel(actor.dat_id, b"bck")
+                    .map(|a| (a, 1.0))
+                    .or_else(|| {
+                        // No dedicated bck clip on PC skels — play run
+                        // reversed in time to fake the backpedal cycle.
+                        crate::combat_stance::run_anim_for_skel(actor.dat_id).map(|a| (a, -1.0))
+                    })
+                    .or_else(|| idle_anim_for_file(actor.dat_id).map(|a| (a, 1.0))),
+                ClipId::StrafeLeft => crate::combat_stance::directional_anim_for_skel(actor.dat_id, b"stl")
+                    .or_else(|| crate::combat_stance::run_anim_for_skel(actor.dat_id))
+                    .or_else(|| idle_anim_for_file(actor.dat_id))
+                    .map(|a| (a, 1.0)),
+                ClipId::StrafeRight => crate::combat_stance::directional_anim_for_skel(actor.dat_id, b"str")
+                    .or_else(|| crate::combat_stance::run_anim_for_skel(actor.dat_id))
+                    .or_else(|| idle_anim_for_file(actor.dat_id))
+                    .map(|a| (a, 1.0)),
+                ClipId::TurnInPlace => crate::combat_stance::directional_anim_for_skel(actor.dat_id, b"trn")
+                    .or_else(|| idle_anim_for_file(actor.dat_id))
+                    .map(|a| (a, 1.0)),
+                ClipId::Walk => crate::combat_stance::directional_anim_for_skel(actor.dat_id, b"wlk")
+                    .or_else(|| crate::combat_stance::run_anim_for_skel(actor.dat_id))
+                    .or_else(|| idle_anim_for_file(actor.dat_id))
+                    .map(|a| (a, 1.0)),
+                ClipId::Idle => idle_anim_for_file(actor.dat_id).map(|a| (a, 1.0)),
+            }
+        };
+
+        // Advance / start the cross-fade. After this call the blend's
+        // `to_clip` is `clip_id`; on a fresh switch `t = 0`; on a
+        // stable selection `t` ticks toward 1.
+        blends.update(world.id, clip_id, dt);
+        let blend = blends.by_id.get(&world.id).copied().expect("just inserted");
+
+        let Some((to_anim, to_scale)) = resolve(blend.to_clip) else {
             continue;
         };
-        if anim.frames == 0 {
-            continue;
-        }
-        let safe_speed = if anim.speed > 0.0 { anim.speed } else { 1.0 };
-        let frame_idx = ((elapsed / safe_speed).floor() as usize) % anim.frames as usize;
+        // While the blend is still in flight, sample both `from` and
+        // `to` and lerp per-bone. Once `t >= 1`, skip the `from` sample
+        // entirely — saves a DAT lookup + map walk.
+        let from_resolved = if blend.t < 1.0 && blend.from_clip != blend.to_clip {
+            resolve(blend.from_clip)
+        } else {
+            None
+        };
+
+        // Convert (anim, time_scale_signum) → current frame index. A
+        // negative `time_scale` runs the clip backwards (used for the
+        // run-as-backpedal fallback).
+        let frame_of = |anim: &ffxi_dat::anim::Mo2Animation, scale: f32| -> usize {
+            if anim.frames == 0 {
+                return 0;
+            }
+            let safe_speed = if anim.speed > 0.0 { anim.speed } else { 1.0 };
+            let t_local = elapsed * scale / safe_speed;
+            // Rust % can be negative; wrap into [0, frames).
+            let frames = anim.frames as i64;
+            let raw = t_local.floor() as i64;
+            let idx = ((raw % frames) + frames) % frames;
+            idx as usize
+        };
+        let to_frame = frame_of(&to_anim, to_scale);
+        let from_frame = from_resolved
+            .as_ref()
+            .map(|(a, s)| frame_of(a, *s))
+            .unwrap_or(0);
+
+        let blend_t = blend.t.clamp(0.0, 1.0);
 
         for (i, bone) in raw.bones.iter().enumerate() {
             // Bone[0] carries the `bind_to_bevy` axis flip set up in
@@ -1703,16 +1811,46 @@ pub fn tick_skinned_actors(
             let Some(&bone_e) = actor.bone_entities.get(i) else {
                 continue;
             };
-            // Sample the animated local for this bone if MO2 drives it;
-            // fall back to the bone's bind-time local otherwise.
-            let (rot, trans, scale) = match anim
+
+            // Sample `to` first (always live). Then optionally sample
+            // `from` and slerp / lerp by `blend_t`.
+            let (to_rot, to_trans, to_scale_arr) = match to_anim
                 .per_bone
                 .get(&(i as u32))
-                .and_then(|frames| frames.get(frame_idx))
+                .and_then(|frames| frames.get(to_frame))
             {
                 Some(f) => (f.rotation, f.translation, f.scale),
                 None => (bone.rot, bone.trans, [1.0, 1.0, 1.0]),
             };
+
+            let (rot, trans, scale) = match from_resolved.as_ref() {
+                Some((from_anim, _)) => {
+                    let (from_rot, from_trans, from_scale_arr) = match from_anim
+                        .per_bone
+                        .get(&(i as u32))
+                        .and_then(|frames| frames.get(from_frame))
+                    {
+                        Some(f) => (f.rotation, f.translation, f.scale),
+                        None => (bone.rot, bone.trans, [1.0, 1.0, 1.0]),
+                    };
+                    let q_from = Quat::from_xyzw(from_rot[0], from_rot[1], from_rot[2], from_rot[3]);
+                    let q_to = Quat::from_xyzw(to_rot[0], to_rot[1], to_rot[2], to_rot[3]);
+                    let q = q_from.slerp(q_to, blend_t);
+                    let t_from = Vec3::from_array(from_trans);
+                    let t_to = Vec3::from_array(to_trans);
+                    let t = t_from.lerp(t_to, blend_t);
+                    let s_from = Vec3::from_array(from_scale_arr);
+                    let s_to = Vec3::from_array(to_scale_arr);
+                    let s = s_from.lerp(s_to, blend_t);
+                    (
+                        [q.x, q.y, q.z, q.w],
+                        [t.x, t.y, t.z],
+                        [s.x, s.y, s.z],
+                    )
+                }
+                None => (to_rot, to_trans, to_scale_arr),
+            };
+
             if let Ok(mut tf) = q_bones.get_mut(bone_e) {
                 tf.rotation = Quat::from_xyzw(rot[0], rot[1], rot[2], rot[3]);
                 tf.translation = Vec3::from_array(trans);

--- a/ffxi-viewer-core/src/lib.rs
+++ b/ffxi-viewer-core/src/lib.rs
@@ -283,6 +283,7 @@ impl<S: SceneSource + Resource> Plugin for ViewerCorePlugin<S> {
         // NOT whether they're currently moving — see [`EntityMotion`]
         // module docs.
         app.init_resource::<combat_stance::EntityMotion>();
+        app.init_resource::<combat_stance::AnimationBlends>();
         #[cfg(not(target_arch = "wasm32"))]
         app.add_systems(
             Update,


### PR DESCRIPTION
## Summary
- Extend `EntityMotion` with signed `forward_component`/`strafe_component` (velocity projected onto facing) plus `heading_rate` for turn-in-place detection.
- Selection rule in `tick_skinned_actors` picks among Idle, Run, Backpedal, StrafeL/R, TurnInPlace, BattleIdle, CombatRun via a new `ClipId` enum. Each ClipId resolves through graceful-degradation fallbacks; `bck`/`stl`/`str`/`trn` are empirically absent from every retail PC skeleton DAT (documented inline) and fall back to `run` (signed time-scale for backpedal) or `idl`.
- Add `AnimationBlends` Resource + per-bone slerp/lerp in `tick_skinned_actors` so clip transitions cross-fade over 150 ms instead of popping.
- Drain both `EntityMotion` and `AnimationBlends` in `despawn_ingame_entities` so a session boundary doesn't carry stale per-actor history (lifecycle-symmetry rule).

## Test plan
- [x] `cargo check -p ffxi-client -p ffxi-viewer-core` clean
- [x] `cargo test -p ffxi-viewer-core combat_stance` — 7/7 pass (existing + threshold test updated for new `MotionSample` shape)
- [x] Wider `cargo test` failures pre-exist on parent commit (verified via `git stash`); not introduced here
- [ ] GUI E2E: walk forward/back/strafe, confirm distinct anims or run-fallback; idle↔run transitions visibly blend over ~0.15s (not performed — no display in agent env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)