### PR TITLE
movement-lock: /sit, /heal, /kneel + RestStance

### DIFF
--- a/ffxi-client/src/view_native/input.rs
+++ b/ffxi-client/src/view_native/input.rs
@@ -187,6 +187,7 @@ pub fn handle_input_system(
     mut lock_on: ResMut<LockOn>,
     cam_q: Query<(&Camera, &Transform), With<OperatorCamera>>,
     mut exit: MessageWriter<AppExit>,
+    mut rest_stance: ResMut<ffxi_viewer_core::combat_stance::RestStance>,
 ) {
     // Close-window: Cmd+Q, Cmd+W, or the OS-level WindowCloseRequested
     // event (red traffic light, App→Quit menu, etc.). Hard-wired (not
@@ -379,6 +380,45 @@ pub fn handle_input_system(
             }
         }
     }
+    // `Action::Sit` / `Action::Heal` press in World mode: toggle the
+    // matching rest stance. Press to enter; press again (or any
+    // movement-action press, handled in `dispatch_movement_system`)
+    // to exit. Default unbound — operator binds via `/keybinds set`.
+    //
+    // Heal goes through the same `AgentCommand::Heal` channel as
+    // the `/heal` slash so the server `EFFECT_HEALING` arms /
+    // clears; `mirror_heal_stance` in `text_input` would normally
+    // mirror that onto the resource, but the dispatcher doesn't run
+    // for direct keypress paths, so we set `RestStance.kind`
+    // ourselves here.
+    if bindings.just_pressed(Action::Sit, &keys) {
+        use ffxi_viewer_core::combat_stance::RestKind;
+        let next = match rest_stance.kind {
+            RestKind::Sit => RestKind::None,
+            // Press Sit while healing → stand up *and* arm Heal::Off
+            // so the server state catches up to the visual.
+            RestKind::Heal => {
+                let _ = cmd_tx.0.try_send(AgentCommand::Heal {
+                    mode: crate::state::HealMode::Off,
+                });
+                RestKind::None
+            }
+            RestKind::None => RestKind::Sit,
+        };
+        rest_stance.kind = next;
+    }
+    if bindings.just_pressed(Action::Heal, &keys) {
+        use ffxi_viewer_core::combat_stance::RestKind;
+        let (next_kind, wire_mode) = match rest_stance.kind {
+            RestKind::Heal => (RestKind::None, crate::state::HealMode::Off),
+            // Toggling Heal from any non-Heal state arms it; the
+            // server-side CAMP applies on the next outbound packet.
+            _ => (RestKind::Heal, crate::state::HealMode::On),
+        };
+        let _ = cmd_tx.0.try_send(AgentCommand::Heal { mode: wire_mode });
+        rest_stance.kind = next_kind;
+    }
+
     if bindings.just_pressed(Action::ToggleLockOn, &keys) {
         let result = lock_on.toggle(target.id);
         let toast = match result {
@@ -490,6 +530,7 @@ pub fn dispatch_movement_system(
     mut prediction: ResMut<LocalPlayerPrediction>,
     navmesh: Res<super::navmesh_overlay::NavmeshState>,
     minimap_hover: Res<ffxi_viewer_core::minimap::input::MinimapHoverGate>,
+    mut rest_stance: ResMut<ffxi_viewer_core::combat_stance::RestStance>,
 ) {
     // Pause walking only when the operator's actively typing (Chat) or
     // making an event choice (Dialog). Menu and QuickAction overlays
@@ -565,6 +606,58 @@ pub fn dispatch_movement_system(
         if zoom_d != 0.0 {
             chase.distance =
                 (chase.distance + zoom_d).clamp(ChaseCamera::DIST_MIN, ChaseCamera::DIST_MAX);
+        }
+    }
+
+    // --- rest-stance gate (sit/heal) ---
+    //
+    // While the local self is in a rest stance, no movement Move
+    // packets emit. Any *press* of a translation or rotation action
+    // (W/S/A/D/Q/E and the bound Strafe* / Turn*) stands the player
+    // up — that's the retail "stand on first input" behavior. The
+    // press is observed via `Bindings::just_pressed` so the cancel
+    // is edge-triggered; holding a key while transitioning into a
+    // rest stance won't fight the new state.
+    //
+    // When Heal is cleared this way we also send `Heal::Off` on the
+    // wire so the server's `EFFECT_HEALING` clears in the same tick
+    // as the client visual. The session loop has its own
+    // movement-detected auto-cancel (`session.rs:1936`), but that
+    // only fires when the keepalive thread next runs *and* observes
+    // a position delta — pre-empting it here keeps the visual /
+    // wire state synced on the press, before any position actually
+    // changes.
+    if rest_stance.is_resting() {
+        use ffxi_viewer_core::combat_stance::RestKind;
+        let move_actions = [
+            Action::MoveForward,
+            Action::MoveBackward,
+            Action::StrafeLeft,
+            Action::StrafeRight,
+            Action::TurnLeft,
+            Action::TurnRight,
+            Action::RotateLeft,
+            Action::RotateRight,
+        ];
+        let pressed_move = move_actions
+            .iter()
+            .any(|a| bindings.just_pressed(*a, &keys));
+        if pressed_move {
+            if matches!(rest_stance.kind, RestKind::Heal) {
+                let _ = cmd_tx.0.try_send(AgentCommand::Heal {
+                    mode: crate::state::HealMode::Off,
+                });
+            }
+            rest_stance.kind = RestKind::None;
+            // Fall through this tick to begin moving — the press
+            // that stood us up is also a valid first frame of
+            // locomotion, matching retail's behavior.
+        } else {
+            // Otherwise: full suppression. No Move emission this
+            // tick, autorun stays off, prediction holds.
+            autorun.phantom_forward = false;
+            autorun.strafe_held_since = None;
+            return;
         }
     }
 

--- a/ffxi-client/src/view_native/slash_commands.rs
+++ b/ffxi-client/src/view_native/slash_commands.rs
@@ -232,14 +232,14 @@ const HELP_CATEGORIES: &[(&str, &[HelpEntry])] = &[
         "Status & Menus",
         &[
             HelpEntry {
-                aliases: &["sit"],
-                usage: "",
-                summary: "sit (not yet wired)",
+                aliases: &["sit", "kneel"],
+                usage: "[on|off]",
+                summary: "sit (locks movement; any movement key stands)",
             },
             HelpEntry {
                 aliases: &["stand"],
                 usage: "",
-                summary: "stand (not yet wired)",
+                summary: "stand (clear any rest stance)",
             },
             HelpEntry {
                 aliases: &["heal"],
@@ -501,6 +501,22 @@ pub enum SlashOutcome {
     /// Mirrors the `SetTarget(Option<u32>)` shape — a client-side
     /// state mutation, no agent/wire side effect.
     ToggleNavmesh(Option<bool>),
+    /// `/sit` / `/kneel` — set or toggle the local
+    /// [`RestStance`][rs] resource. Pure client-side affordance; the
+    /// retail server has no "is sitting" packet, so the dispatcher
+    /// just mutates the resource and the avatar animation system
+    /// picks up the new pose next frame.
+    ///
+    /// `kind = Some(RestStanceKind::Sit)` enters sit, `Some(None)`
+    /// stands, `None` (toggle) flips between the current `Sit`
+    /// stance and `None` (any other stance becomes `Sit`). The
+    /// `/heal` slash command does NOT route through this — it stays
+    /// on `AgentCommand::Heal` so the server-side CAMP machinery
+    /// runs, and the dispatcher mirrors `RestStance::Heal` on the
+    /// outbound side.
+    ///
+    /// [rs]: ffxi_viewer_core::combat_stance::RestStance
+    SetSitStance(SitToggle),
     /// `/keybinds preset|list|reset` — switch keybind preset, list the
     /// active map, or drop overrides back to the active preset's
     /// defaults. The dispatcher applies the change to the `Bindings`
@@ -733,6 +749,23 @@ pub enum SoundOp {
     SetSfx(Option<bool>),
 }
 
+/// `/sit` / `/kneel` argument variants. The parser turns the user's
+/// text into one of these; the dispatcher applies it to the
+/// [`RestStance`][rs] resource.
+///
+/// [rs]: ffxi_viewer_core::combat_stance::RestStance
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SitToggle {
+    /// Bare `/sit` or `/kneel` — flip Sit on/off. (`Heal` → `Sit`
+    /// when toggled, mirroring how retail's `/sit` while healing
+    /// stands you up out of CAMP and then sits.)
+    Toggle,
+    /// `/sit on` — explicitly enter Sit.
+    On,
+    /// `/sit off` or `/stand` — explicitly clear any rest stance.
+    Off,
+}
+
 /// `/agent` subcommand variants.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AgentControlOp {
@@ -938,8 +971,14 @@ pub fn parse_slash(
             }
         }
         "buy" => parse_buy(rest),
-        "sit" => SlashOutcome::SystemMessage("/sit: not yet wired".into()),
-        "stand" => SlashOutcome::SystemMessage("/stand: not yet wired".into()),
+        // `/sit` / `/kneel` — retail aliases for the sit rest pose. Pure
+        // client-side affordance: lock the local self avatar in the
+        // sit MO2 and refuse to emit outbound `Move` packets until a
+        // movement key clears the stance (retail-style stand-on-first-
+        // input). `/sit on` / `/sit off` are explicit setters; bare
+        // `/sit` toggles.
+        "sit" | "kneel" => parse_sit(rest),
+        "stand" => SlashOutcome::SetSitStance(SitToggle::Off),
         "bgm" => match rest.parse::<u16>() {
             Ok(id) => SlashOutcome::PlayBgm { track_id: id },
             Err(_) => SlashOutcome::SystemMessage("/bgm <track_id>".into()),
@@ -1187,6 +1226,24 @@ fn parse_reqlogout(rest: &str, shutdown: bool) -> SlashOutcome {
 /// `/heal [on|off]` — toggle/arm/cancel resting (0x0E8 CAMP). Empty arg
 /// is the always-safe Toggle form. Unknown arg → system message,
 /// mirroring `parse_reqlogout`'s usage-line shape.
+/// `/sit [on|off|toggle]` — parses the SitToggle variant for the
+/// rest-stance dispatcher. Bare `/sit` (or `/kneel`) toggles; unknown
+/// args produce a system message.
+fn parse_sit(rest: &str) -> SlashOutcome {
+    let arg = rest.trim().to_ascii_lowercase();
+    let toggle = match arg.as_str() {
+        "" | "toggle" => SitToggle::Toggle,
+        "on" => SitToggle::On,
+        "off" => SitToggle::Off,
+        other => {
+            return SlashOutcome::SystemMessage(format!(
+                "/sit: usage `/sit [on|off]` (got `{other}`)"
+            ));
+        }
+    };
+    SlashOutcome::SetSitStance(toggle)
+}
+
 fn parse_heal(rest: &str) -> SlashOutcome {
     let arg = rest.trim().to_ascii_lowercase();
     let mode = match arg.as_str() {
@@ -3280,6 +3337,44 @@ mod tests {
                 ),
                 "expected SystemMessage for {s}"
             );
+        }
+    }
+
+    #[test]
+    fn sit_no_arg_toggles() {
+        match parse_slash_t("/sit", &empty_entities(), origin(), None, None) {
+            SlashOutcome::SetSitStance(t) => assert_eq!(t, SitToggle::Toggle),
+            other => panic!("expected SetSitStance(Toggle), got {other:?}"),
+        }
+        // `/kneel` is the retail alias for `/sit`.
+        match parse_slash_t("/kneel", &empty_entities(), origin(), None, None) {
+            SlashOutcome::SetSitStance(t) => assert_eq!(t, SitToggle::Toggle),
+            other => panic!("expected SetSitStance(Toggle), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sit_on_off_and_stand() {
+        match parse_slash_t("/sit on", &empty_entities(), origin(), None, None) {
+            SlashOutcome::SetSitStance(t) => assert_eq!(t, SitToggle::On),
+            other => panic!("expected SetSitStance(On), got {other:?}"),
+        }
+        match parse_slash_t("/sit off", &empty_entities(), origin(), None, None) {
+            SlashOutcome::SetSitStance(t) => assert_eq!(t, SitToggle::Off),
+            other => panic!("expected SetSitStance(Off), got {other:?}"),
+        }
+        // `/stand` is the retail standalone-form of `/sit off`.
+        match parse_slash_t("/stand", &empty_entities(), origin(), None, None) {
+            SlashOutcome::SetSitStance(t) => assert_eq!(t, SitToggle::Off),
+            other => panic!("expected SetSitStance(Off), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sit_rejects_unknown_arg() {
+        match parse_slash_t("/sit bogus", &empty_entities(), origin(), None, None) {
+            SlashOutcome::SystemMessage(s) => assert!(s.contains("/sit:"), "{s}"),
+            other => panic!("expected SystemMessage, got {other:?}"),
         }
     }
 

--- a/ffxi-client/src/view_native/text_input.rs
+++ b/ffxi-client/src/view_native/text_input.rs
@@ -140,6 +140,12 @@ pub struct SlashWriters<'w, 's> {
     /// can clamp against the zone's half-span (same logic the
     /// scroll-wheel handler uses).
     pub minimap_state: Res<'w, ffxi_viewer_core::minimap::MinimapState>,
+    /// `/sit` / `/kneel` / `/stand` and the heal-arming slash twin
+    /// mirror the local rest-stance state here. Read by the movement
+    /// dispatcher (to suppress Move emission while resting) and by
+    /// `tick_skinned_actors` (to pick the sit / hea MO2 on the self
+    /// avatar).
+    pub rest_stance: ResMut<'w, ffxi_viewer_core::combat_stance::RestStance>,
 }
 use tokio::sync::mpsc::Sender;
 
@@ -615,6 +621,7 @@ fn apply_slash_outcome(
                     .logout_requested
                     .write(ffxi_viewer_core::hud::logout_countdown::LogoutRequested { shutdown });
             }
+            mirror_heal_stance(&cmd, &mut slash_writers.rest_stance);
             let send_result = cmd_tx.try_send(cmd);
             if let Err(e) = send_result {
                 // Channel full or closed — operator should see this; silent
@@ -633,6 +640,7 @@ fn apply_slash_outcome(
                 if let Some(toast) = reqlogout_ack_text(&cmd) {
                     push_system_chat_line(scene_state, toast.into());
                 }
+                mirror_heal_stance(&cmd, &mut slash_writers.rest_stance);
                 if let Some(shutdown) = reqlogout_starts_countdown(&cmd) {
                     slash_writers.logout_requested.write(
                         ffxi_viewer_core::hud::logout_countdown::LogoutRequested { shutdown },
@@ -683,6 +691,37 @@ fn apply_slash_outcome(
             for line in text.split('\n') {
                 push_system_chat_line(scene_state, line.to_string());
             }
+        }
+        SlashOutcome::SetSitStance(toggle) => {
+            use ffxi_viewer_core::combat_stance::RestKind;
+            use crate::view_native::slash_commands::SitToggle;
+            let next = match toggle {
+                SitToggle::On => RestKind::Sit,
+                SitToggle::Off => RestKind::None,
+                SitToggle::Toggle => match slash_writers.rest_stance.kind {
+                    RestKind::Sit => RestKind::None,
+                    // From any other stance, /sit enters Sit. If we were
+                    // in Heal, the heal-cancel keepalive arms when the
+                    // server sees position drift; without that, we'd
+                    // be visually sitting but server-side still
+                    // healing. Send Heal::Off explicitly to bring the
+                    // two surfaces back into sync.
+                    RestKind::Heal => {
+                        let _ = cmd_tx.try_send(AgentCommand::Heal {
+                            mode: crate::state::HealMode::Off,
+                        });
+                        RestKind::Sit
+                    }
+                    RestKind::None => RestKind::Sit,
+                },
+            };
+            slash_writers.rest_stance.kind = next;
+            let label = match next {
+                RestKind::Sit => "sitting",
+                RestKind::Heal => "healing",
+                RestKind::None => "standing",
+            };
+            push_system_chat_line(scene_state, format!("/sit: {label}"));
         }
         SlashOutcome::ToggleNavmesh(setting) => {
             let next = setting.unwrap_or(!navmesh_visible.0);
@@ -1454,6 +1493,36 @@ fn reqlogout_ack_text(cmd: &AgentCommand) -> Option<&'static str> {
         }
         ReqLogoutKind::ShutdownOff => "/shutdown: cancel requested",
     })
+}
+
+/// Mirror an outbound `AgentCommand::Heal` onto the local
+/// [`RestStance`] resource so the avatar animation + movement-lock
+/// machinery sees the same state the server is about to apply. The
+/// session loop also tracks `is_healing` for its own keepalive
+/// auto-cancel, but that's wire-side; this is the visual / input
+/// side. Non-Heal commands are no-ops.
+fn mirror_heal_stance(
+    cmd: &AgentCommand,
+    rest: &mut ffxi_viewer_core::combat_stance::RestStance,
+) {
+    use ffxi_viewer_core::combat_stance::RestKind;
+    let AgentCommand::Heal { mode } = cmd else {
+        return;
+    };
+    let next = match mode {
+        crate::state::HealMode::On => RestKind::Heal,
+        crate::state::HealMode::Off => match rest.kind {
+            // Only clear when we were the one healing — preserves a
+            // /sit stance someone bizarrely sent Heal::Off during.
+            RestKind::Heal => RestKind::None,
+            other => other,
+        },
+        crate::state::HealMode::Toggle => match rest.kind {
+            RestKind::Heal => RestKind::None,
+            _ => RestKind::Heal,
+        },
+    };
+    rest.kind = next;
 }
 
 /// Local chat-line echo for `/say`, `/sh`, `/p`, `/l`, `/y` etc. The

--- a/ffxi-viewer-core/src/combat_stance.rs
+++ b/ffxi-viewer-core/src/combat_stance.rs
@@ -83,6 +83,15 @@ static BATTLE_IDLE_ANIMS: OnceLock<Mutex<HashMap<u32, Option<Arc<Mo2Animation>>>
 /// too — the existence check is the load itself.
 static RUN_ANIMS: OnceLock<Mutex<HashMap<u32, Option<Arc<Mo2Animation>>>>> = OnceLock::new();
 
+/// Cache for the resting `sit` / `hea` animations. Keyed by skeleton
+/// DAT id; both clips live in the skeleton DAT on PC races (sit/hea
+/// are not weapon-class-specific, so they don't have motion-DAT
+/// variants). `None` is cached for skeletons that don't ship the
+/// clip — NPC skels routinely lack `hea` even when they have `sit`,
+/// so the lookup must be independent per clip.
+static SIT_ANIMS: OnceLock<Mutex<HashMap<u32, Option<Arc<Mo2Animation>>>>> = OnceLock::new();
+static HEAL_ANIMS: OnceLock<Mutex<HashMap<u32, Option<Arc<Mo2Animation>>>>> = OnceLock::new();
+
 /// Cache for the combat run animation in the motion DAT (`run1`,
 /// 68-bone full rig). PC-only; keyed by motion DAT id like
 /// [`BATTLE_IDLE_ANIMS`].
@@ -160,6 +169,83 @@ pub fn combat_run_anim_for_skel(skel_file_id: u32) -> Option<Arc<Mo2Animation>> 
     let loaded = load_anim_with_prefix(motion_dat, b"run").map(Arc::new);
     guard.insert(motion_dat, loaded.clone());
     loaded
+}
+
+/// Load the `sit` rest-pose MO2 from the skeleton DAT. Lotus's
+/// `actor_skeleton_static.cpp` resolves `/sit` against the same
+/// name-keyed animation map as `idle` / `run`, so the clip lives in
+/// the skeleton DAT (not the motion DAT). Some NPC skels ship it
+/// (chairs etc. that play "sit" on idle); most don't, so `None` is
+/// expected for the majority of skel ids.
+pub fn sit_anim_for_skel(skel_file_id: u32) -> Option<Arc<Mo2Animation>> {
+    let map = SIT_ANIMS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard = map.lock().ok()?;
+    if let Some(entry) = guard.get(&skel_file_id) {
+        return entry.clone();
+    }
+    let loaded = load_anim_with_prefix(skel_file_id, b"sit").map(Arc::new);
+    guard.insert(skel_file_id, loaded.clone());
+    loaded
+}
+
+/// Load the `hea` (heal / CAMP rest) MO2 from the skeleton DAT. PC-only
+/// in practice — the rest crouch animation is the same one the server
+/// gates `EFFECT_HEALING` on, and only the seven playable race skels
+/// ship it.
+pub fn heal_anim_for_skel(skel_file_id: u32) -> Option<Arc<Mo2Animation>> {
+    let map = HEAL_ANIMS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard = map.lock().ok()?;
+    if let Some(entry) = guard.get(&skel_file_id) {
+        return entry.clone();
+    }
+    let loaded = load_anim_with_prefix(skel_file_id, b"hea").map(Arc::new);
+    guard.insert(skel_file_id, loaded.clone());
+    loaded
+}
+
+/// Which rest stance the local self is currently in. Set by the
+/// `/sit` / `/heal` / `/kneel` slash commands and by the bound
+/// `Action::Sit` / `Action::Heal` keypresses; cleared by any
+/// movement-input press (`MoveForward` / `Backward` / `Strafe*` /
+/// `Turn*` / `Rotate*`) per retail FFXI behavior — stand-on-first-
+/// input.
+///
+/// While `kind != None`:
+///   - `dispatch_movement_system` discards translation and rotation
+///     deltas (and the *press* of any movement Action clears the
+///     stance back to `None`);
+///   - `tick_skinned_actors` selects the matching `sit` / `hea` MO2
+///     on the self avatar and treats it as uninterruptible
+///     (no cross-fade out until cleared);
+///   - the keepalive thread for `Heal` still arms server-side
+///     `EFFECT_HEALING` via the `AgentCommand::Heal` send path —
+///     this resource is the *visual / local-input* surface, not
+///     the wire protocol surface.
+///
+/// `Sit` is a pure client-side affordance — there is no `0x0Eb sit`
+/// packet in retail. The server has no opinion on a player sitting.
+#[derive(Resource, Default, Debug, Clone, Copy, Eq, PartialEq)]
+pub struct RestStance {
+    pub kind: RestKind,
+}
+
+/// Which rest-pose is active.
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+pub enum RestKind {
+    /// Not resting — normal locomotion / engagement animation rules apply.
+    #[default]
+    None,
+    /// `/sit` or `/kneel` — pure visual.
+    Sit,
+    /// `/heal` — server-armed CAMP plus visual.
+    Heal,
+}
+
+impl RestStance {
+    /// True if any rest pose is held.
+    pub fn is_resting(&self) -> bool {
+        !matches!(self.kind, RestKind::None)
+    }
 }
 
 /// Shared loader: open a DAT, walk its chunks, return the first MO2
@@ -359,6 +445,19 @@ mod tests {
         assert!(m.is_moving(3), "just above 0.5 should animate");
         assert!(m.is_moving(4), "full run speed should animate");
         assert!(!m.is_moving(99), "unknown id should not animate");
+    }
+
+    /// `RestStance::is_resting` reflects the kind variant.
+    #[test]
+    fn rest_stance_is_resting_matches_kind() {
+        let mut s = RestStance::default();
+        assert!(!s.is_resting());
+        s.kind = RestKind::Sit;
+        assert!(s.is_resting());
+        s.kind = RestKind::Heal;
+        assert!(s.is_resting());
+        s.kind = RestKind::None;
+        assert!(!s.is_resting());
     }
 
     /// Combat run lives in the motion DAT as `run1` (68-bone LOD).

--- a/ffxi-viewer-core/src/dat_vos2.rs
+++ b/ffxi-viewer-core/src/dat_vos2.rs
@@ -1639,6 +1639,7 @@ pub fn tick_skinned_actors(
     time: Res<Time>,
     state: Res<crate::snapshot::SceneState>,
     motion: Res<crate::combat_stance::EntityMotion>,
+    rest: Res<crate::combat_stance::RestStance>,
     q_actors: Query<(&crate::components::WorldEntity, &SkinnedActor)>,
     mut q_bones: Query<&mut Transform>,
 ) {
@@ -1663,6 +1664,59 @@ pub fn tick_skinned_actors(
             .map(|e| e.bt_target_id != 0)
             .unwrap_or(false);
         let moving = motion.is_moving(world.id);
+
+        // Rest stance (self only): when `/sit` / `/heal` / `/kneel` is
+        // active, self plays the sit / hea MO2 uninterruptibly until
+        // the [`RestStance`] resource clears (cleared by movement-key
+        // press in `dispatch_movement_system`, by re-pressing the
+        // bound `Action::Sit` / `Action::Heal`, or by server-driven
+        // heal-off when actual translation is detected). No
+        // crossfade — same hard toggle as the rest of the matrix.
+        let is_self = state
+            .snapshot
+            .self_char_id
+            .map(|sid| sid == world.id)
+            .unwrap_or(false);
+        if is_self {
+            use crate::combat_stance::RestKind;
+            let rest_anim = match rest.kind {
+                RestKind::Sit => crate::combat_stance::sit_anim_for_skel(actor.dat_id)
+                    .or_else(|| idle_anim_for_file(actor.dat_id)),
+                RestKind::Heal => crate::combat_stance::heal_anim_for_skel(actor.dat_id)
+                    .or_else(|| crate::combat_stance::sit_anim_for_skel(actor.dat_id))
+                    .or_else(|| idle_anim_for_file(actor.dat_id)),
+                RestKind::None => None,
+            };
+            if let Some(anim) = rest_anim {
+                if anim.frames > 0 {
+                    let safe_speed = if anim.speed > 0.0 { anim.speed } else { 1.0 };
+                    let frame_idx =
+                        ((elapsed / safe_speed).floor() as usize) % anim.frames as usize;
+                    for (i, bone) in raw.bones.iter().enumerate() {
+                        if i == 0 {
+                            continue;
+                        }
+                        let Some(&bone_e) = actor.bone_entities.get(i) else {
+                            continue;
+                        };
+                        let (rot, trans, scale) = match anim
+                            .per_bone
+                            .get(&(i as u32))
+                            .and_then(|frames| frames.get(frame_idx))
+                        {
+                            Some(f) => (f.rotation, f.translation, f.scale),
+                            None => (bone.rot, bone.trans, [1.0, 1.0, 1.0]),
+                        };
+                        if let Ok(mut tf) = q_bones.get_mut(bone_e) {
+                            tf.rotation = Quat::from_xyzw(rot[0], rot[1], rot[2], rot[3]);
+                            tf.translation = Vec3::from_array(trans);
+                            tf.scale = Vec3::from_array(scale);
+                        }
+                    }
+                    continue;
+                }
+            }
+        }
 
         // Pick the right anim per the (engaged, moving) matrix in
         // the doc comment above. Each `or_else` is a graceful

--- a/ffxi-viewer-core/src/keybinds/mod.rs
+++ b/ffxi-viewer-core/src/keybinds/mod.rs
@@ -115,6 +115,17 @@ pub enum Action {
     /// the reactor goal. The server's auto-attack timer drives subsequent
     /// 0x028 BATTLE2 packets while engaged.
     ToggleEngage,
+    /// Toggle the `Sit` rest stance (retail `/sit` + `/kneel`). Press to
+    /// enter — character locks to a sitting pose, all movement input is
+    /// converted to "stand up" until pressed again. Default unbound;
+    /// operator can rebind via `/keybinds set sit ...`.
+    Sit,
+    /// Toggle the `Heal` rest stance (retail `/heal` / CAMP). Sends the
+    /// server-side `AgentCommand::Heal { mode: Toggle }` to arm/clear
+    /// `EFFECT_HEALING`; locally mirrors that state via [`RestStance`]
+    /// so the avatar animates `hea` and movement input cancels the
+    /// rest the same way retail does. Default unbound.
+    Heal,
 
     // ----- UI activation (World mode) -----
     /// Open chat with empty buffer (default Space).

--- a/ffxi-viewer-core/src/lib.rs
+++ b/ffxi-viewer-core/src/lib.rs
@@ -283,6 +283,7 @@ impl<S: SceneSource + Resource> Plugin for ViewerCorePlugin<S> {
         // NOT whether they're currently moving — see [`EntityMotion`]
         // module docs.
         app.init_resource::<combat_stance::EntityMotion>();
+        app.init_resource::<combat_stance::RestStance>();
         #[cfg(not(target_arch = "wasm32"))]
         app.add_systems(
             Update,


### PR DESCRIPTION
## Summary
- Adds a client-side `RestStance` resource (combat_stance.rs) with `RestKind::{None, Sit, Heal}` so other systems can query "is the player resting?".
- Wires `/sit` / `/kneel` / `/stand` slash commands (previously stubbed) + adds `Action::Sit` and `Action::Heal` to the bindings table (default unbound).
- While resting: `dispatch_movement_system` suppresses Move emission and autorun; any movement-key press stands the player up (retail "stand on first input"). Clearing out of Heal also ships `AgentCommand::Heal { Off }` so the server `EFFECT_HEALING` clears in the same tick.
- `tick_skinned_actors` selects `sit` / `hea` MO2 on the local self avatar; falls back to idle if the clip is missing.
- `/heal` still routes through the existing server-side CAMP path; `mirror_heal_stance` mirrors the outbound mode onto the local resource.

## Test plan
- [x] `cargo check -p ffxi-viewer-core` clean
- [x] `cargo check -p ffxi-client --features=native-window,relay` clean
- [x] `cargo test -p ffxi-viewer-core --lib combat_stance` — 8 passed (1 new test for `RestStance::is_resting`)
- [x] `cargo test -p ffxi-viewer-core --lib keybinds` — 16 passed
- [x] `cargo test -p ffxi-client --bin ffxi-client --features=native-window,relay slash` — 87 passed (3 new tests: `sit_no_arg_toggles`, `sit_on_off_and_stand`, `sit_rejects_unknown_arg`)
- [ ] E2E manual: `/sit` locks movement; W stands and walks; `/heal` triggers `hea` anim; `/kneel` alias works. Not run locally — GUI requires `cargo run -p ffxi-client --features=native-window,relay -- --agent-listen auto native claude testpass123`.

## Notes
- One pre-existing test failure observed but unrelated to this change: `view_native::text_input::menu_dispatch_tests::unwired_root_entries_stay_not_implemented` expected `Magic` to still be a stub, but Magic submenu was wired in commit `d6129e7` (before this worktree branched from main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)