### PR TITLE
feat: decode s2c 0x055 key items (SCENARIO_ITEM)

### DIFF
--- a/ffxi-client/src/session.rs
+++ b/ffxi-client/src/session.rs
@@ -860,6 +860,14 @@ fn handle_sub_packet(
             let recasts = decode_abil_recast(sub.data);
             let _ = event_tx.send(AgentEvent::AbilityRecastsUpdated { recasts });
         }
+        op if op == s2c::SCENARIO_ITEM => {
+            if let Ok(ki) = decode::ScenarioItem::decode(sub.data) {
+                let _ = event_tx.send(AgentEvent::KeyItemsUpdated {
+                    table_index: ki.table_index,
+                    ids: ki.owned_key_item_ids(),
+                });
+            }
+        }
         op if op == s2c::EVENT => {
             if let Some(dialog) = decode_event_0x032(sub.data) {
                 emit_event_dialog(event_tx, &dialog, pending_event_end, name_cache);

--- a/ffxi-client/src/state.rs
+++ b/ffxi-client/src/state.rs
@@ -303,9 +303,14 @@ pub struct SessionState {
 
     #[serde(default)]
     pub pet_abilities_known: Vec<u16>,
+
+    #[serde(default)]
+    pub key_items: Vec<u16>,
 }
 
 pub const EQUIPMENT_SLOTS: usize = 16;
+
+pub const KEY_ITEMS_PER_TABLE: usize = ffxi_proto::decode::ScenarioItem::BITS_PER_TABLE;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EquippedRef {
@@ -802,6 +807,15 @@ impl SessionState {
                 self.job_abilities_known = job_abilities.clone();
                 self.pet_abilities_known = pet_abilities.clone();
             }
+            AgentEvent::KeyItemsUpdated { table_index, ids } => {
+                let base = *table_index as usize * KEY_ITEMS_PER_TABLE;
+                let table_range = base..base + KEY_ITEMS_PER_TABLE;
+                self.key_items
+                    .retain(|id| !table_range.contains(&(*id as usize)));
+                self.key_items.extend(ids.iter().copied());
+                self.key_items.sort_unstable();
+                self.key_items.dedup();
+            }
 
             AgentEvent::EventStart { .. } | AgentEvent::KeyRotated { .. } => {}
             AgentEvent::EventDialog { dialog } => {
@@ -1001,6 +1015,11 @@ pub enum AgentEvent {
         weapon_skills: Vec<u16>,
         job_abilities: Vec<u16>,
         pet_abilities: Vec<u16>,
+    },
+
+    KeyItemsUpdated {
+        table_index: u16,
+        ids: Vec<u16>,
     },
 
     ReactorGoalChanged {
@@ -1415,6 +1434,26 @@ mod tests {
             to: 231,
         });
         assert_eq!(s.current_weather, None);
+    }
+
+    #[test]
+    fn key_items_merge_across_tables_and_replace_in_place() {
+        let mut s = SessionState::default();
+        s.apply_event(&AgentEvent::KeyItemsUpdated {
+            table_index: 0,
+            ids: vec![1, 5],
+        });
+        s.apply_event(&AgentEvent::KeyItemsUpdated {
+            table_index: 1,
+            ids: vec![KEY_ITEMS_PER_TABLE as u16],
+        });
+        assert_eq!(s.key_items, vec![1, 5, KEY_ITEMS_PER_TABLE as u16]);
+
+        s.apply_event(&AgentEvent::KeyItemsUpdated {
+            table_index: 0,
+            ids: vec![5],
+        });
+        assert_eq!(s.key_items, vec![5, KEY_ITEMS_PER_TABLE as u16]);
     }
 
     #[test]

--- a/ffxi-client/src/view_native/text_input.rs
+++ b/ffxi-client/src/view_native/text_input.rs
@@ -1906,6 +1906,9 @@ fn resolve_menu_entry(kind: MenuKind, label: &str) -> MenuDispatch {
         (MenuKind::Root, "Magic") => MenuDispatch::OpenSubmenu(MenuKind::Magic),
         (MenuKind::Root, "Abilities") => MenuDispatch::OpenSubmenu(MenuKind::Abilities),
         (MenuKind::Root, "Items") => MenuDispatch::OpenSubmenu(MenuKind::Items),
+        (MenuKind::Root, "Key Items") => {
+            MenuDispatch::NotImplemented("Key Items — pending submenu (s2c 0x055 decoded)".into())
+        }
         (MenuKind::Root, "Equipment") => MenuDispatch::OpenSubmenu(MenuKind::Equipment),
 
         (MenuKind::Root, "Status") => MenuDispatch::OpenSubmenu(MenuKind::Status),

--- a/ffxi-mcp/src/main.rs
+++ b/ffxi-mcp/src/main.rs
@@ -815,6 +815,7 @@ fn event_kind_label(ev: &AgentEvent) -> &'static str {
         AgentEvent::SkillLevelUp { .. } => "skill_level_up",
         AgentEvent::ActionStarted { .. } => "action_started",
         AgentEvent::VanaTimeSynced { .. } => "vana_time_synced",
+        AgentEvent::KeyItemsUpdated { .. } => "key_items_updated",
     }
 }
 

--- a/ffxi-proto/src/decode.rs
+++ b/ffxi-proto/src/decode.rs
@@ -509,6 +509,60 @@ pub fn decode_weather(sub: &SubPacket<'_>) -> Result<WeatherPacket, DecodeError>
     WeatherPacket::decode(sub.data)
 }
 
+/// s2c 0x055 GP_SERV_COMMAND_SCENARIOITEM (key items). One packet carries a
+/// single 512-bit table: 16 u32 `GetItemFlag` (owned) followed by 16 u32
+/// `LookItemFlag` (examined), then the `TableIndex`. A key-item's global id is
+/// `table_index * 512 + bit`.
+/// vendor/server/src/map/packets/s2c/0x055_scenarioitem.h
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScenarioItem {
+    pub table_index: u16,
+    pub get_flags: [u32; Self::WORDS],
+    pub look_flags: [u32; Self::WORDS],
+}
+
+impl ScenarioItem {
+    pub const WORDS: usize = 16;
+    pub const BITS_PER_TABLE: usize = Self::WORDS * 32;
+    pub const SIZE: usize = Self::WORDS * 4 * 2 + 4;
+
+    pub fn decode(body: &[u8]) -> Result<Self, DecodeError> {
+        if body.len() < Self::SIZE {
+            return Err(DecodeError::Truncated(Self::SIZE, body.len()));
+        }
+        let rd = |o: usize| u32::from_le_bytes([body[o], body[o + 1], body[o + 2], body[o + 3]]);
+        let mut get_flags = [0u32; Self::WORDS];
+        let mut look_flags = [0u32; Self::WORDS];
+        for i in 0..Self::WORDS {
+            get_flags[i] = rd(i * 4);
+            look_flags[i] = rd(Self::WORDS * 4 + i * 4);
+        }
+        let table_index = u16::from_le_bytes([body[Self::WORDS * 8], body[Self::WORDS * 8 + 1]]);
+        Ok(Self {
+            table_index,
+            get_flags,
+            look_flags,
+        })
+    }
+
+    pub fn owned_key_item_ids(&self) -> Vec<u16> {
+        let base = self.table_index as usize * Self::BITS_PER_TABLE;
+        let mut ids = Vec::new();
+        for (word, &flags) in self.get_flags.iter().enumerate() {
+            for bit in 0..32 {
+                if flags & (1 << bit) != 0 {
+                    ids.push((base + word * 32 + bit) as u16);
+                }
+            }
+        }
+        ids
+    }
+}
+
+pub fn decode_scenario_item(sub: &SubPacket<'_>) -> Result<ScenarioItem, DecodeError> {
+    ScenarioItem::decode(sub.data)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum PosMode {
@@ -1988,6 +2042,55 @@ mod tests {
         assert!(matches!(
             CharStatus::decode(&buf),
             Err(DecodeError::Truncated(n, have)) if n == need && have == need - 1
+        ));
+    }
+}
+
+#[cfg(test)]
+mod scenario_item_tests {
+    use super::*;
+
+    fn body_with(table_index: u16, get: &[(usize, u32)], look: &[(usize, u32)]) -> Vec<u8> {
+        let mut body = vec![0u8; ScenarioItem::SIZE];
+        for &(word, flags) in get {
+            body[word * 4..word * 4 + 4].copy_from_slice(&flags.to_le_bytes());
+        }
+        for &(word, flags) in look {
+            let o = ScenarioItem::WORDS * 4 + word * 4;
+            body[o..o + 4].copy_from_slice(&flags.to_le_bytes());
+        }
+        let o = ScenarioItem::WORDS * 8;
+        body[o..o + 2].copy_from_slice(&table_index.to_le_bytes());
+        body
+    }
+
+    #[test]
+    fn decodes_table_index_and_flags() {
+        let body = body_with(2, &[(0, 0b101), (3, 1 << 7)], &[(0, 0b10)]);
+        let si = ScenarioItem::decode(&body).expect("decode");
+        assert_eq!(si.table_index, 2);
+        assert_eq!(si.get_flags[0], 0b101);
+        assert_eq!(si.get_flags[3], 1 << 7);
+        assert_eq!(si.look_flags[0], 0b10);
+    }
+
+    #[test]
+    fn owned_ids_account_for_table_offset() {
+        let body = body_with(2, &[(0, 0b101), (3, 1 << 7)], &[]);
+        let si = ScenarioItem::decode(&body).expect("decode");
+        let base = 2 * ScenarioItem::BITS_PER_TABLE;
+        assert_eq!(
+            si.owned_key_item_ids(),
+            vec![base as u16, (base + 2) as u16, (base + 3 * 32 + 7) as u16,]
+        );
+    }
+
+    #[test]
+    fn truncated_body_is_error() {
+        let buf = vec![0u8; ScenarioItem::SIZE - 1];
+        assert!(matches!(
+            ScenarioItem::decode(&buf),
+            Err(DecodeError::Truncated(n, have)) if n == ScenarioItem::SIZE && have == ScenarioItem::SIZE - 1
         ));
     }
 }

--- a/ffxi-proto/src/map.rs
+++ b/ffxi-proto/src/map.rs
@@ -114,6 +114,8 @@ pub mod s2c {
 
     pub const SYSTEMMES: u16 = 0x053;
 
+    pub const SCENARIO_ITEM: u16 = 0x055;
+
     pub const WEATHER: u16 = 0x057;
 
     pub const MUSIC: u16 = 0x05F;

--- a/ffxi-viewer-core/src/hud/menu.rs
+++ b/ffxi-viewer-core/src/hud/menu.rs
@@ -8,6 +8,7 @@ const ROOT_ENTRIES: &[&str] = &[
     "Magic",
     "Abilities",
     "Items",
+    "Key Items",
     "Equipment",
     "Status",
     "Party",


### PR DESCRIPTION
Refs #64 (decode + storage; UI submenu still a stub).

## What
- `ffxi-proto`: `s2c::SCENARIO_ITEM = 0x055`; `decode::ScenarioItem` parses the 16×u32 `GetItemFlag` + 16×u32 `LookItemFlag` + `u16 TableIndex` (+`u16` pad), layout per `vendor/server/src/map/packets/s2c/0x055_scenarioitem.h`. `owned_key_item_ids()` expands set bits to global ids (`table*512 + bit`).
- `ffxi-client`: `SessionState.key_items` + `AgentEvent::KeyItemsUpdated`; the 0x055 handler decodes + emits it; apply replaces only the affected 512-id table range and merges/dedups across tables.
- `ffxi-mcp`: event-name label for the new variant.
- hud menu: `Key Items` root entry (NotImplemented stub; submenu pending).

## Verification
- `cargo test -p ffxi-proto scenario_item_tests` (3 tests: bit→id expansion incl. table offset, truncation error) ✓
- `cargo test -p ffxi-client --lib key_items_merge_across_tables_and_replace_in_place` ✓
- `scripts/checks.sh fmt clippy` (full workspace) ✓
- Layout cross-checked against the LSB header.

## Caveats
- UI submenu is a stub; not exercised against a live server (no server in CI).
- Authored via an agent workflow, then human-reviewed + re-verified before this PR.