### PR TITLE
fix: NPC dialog VM stalls, self run-anim persistence, and GM/status speed sync

### DIFF
--- a/ffxi-client/src/session.rs
+++ b/ffxi-client/src/session.rs
@@ -818,6 +818,10 @@ fn handle_sub_packet(
         op if op == s2c::CHAR_STATUS => {
             if let Ok(cs) = decode::CharStatus::decode(sub.data) {
                 if cs.unique_no == self_char_id {
+                    // GM !speed and status effects land here, not in CHAR_PC.
+                    if cs.speed > 0 {
+                        self_pos.speed = cs.speed.min(u16::from(u8::MAX)) as u8;
+                    }
                     let _ = event_tx.send(AgentEvent::DeathTimerUpdated {
                         seconds_until_homepoint: (cs.hpp == 0)
                             .then(|| cs.seconds_until_homepoint()),

--- a/ffxi-client/src/session.rs
+++ b/ffxi-client/src/session.rs
@@ -1281,6 +1281,11 @@ async fn keepalive_loop(
 
     let mut pending_event_end_since: Option<std::time::Instant> = None;
 
+    // Events the VM could not drive (unimplemented opcode / missing DAT):
+    // released immediately on the next send tick so the server never leaves the
+    // character pinned InEvent behind an empty dialog.
+    let mut auto_event_end: Vec<(u32, u16, u16)> = Vec::new();
+
     let mut dialog_session = crate::event_dialog::DialogSession::new(
         npc_name_resolver.root.clone(),
         character_name.clone(),
@@ -1856,6 +1861,15 @@ async fn keepalive_loop(
                         "sent 0x011 ZONE_TRANSITION after 0x008 ENTERZONE (GAMEOK mode)"
                     );
                 }
+                // VM-undriveable events release immediately, GUI or headless.
+                for (unique_no, act_index, event_num) in auto_event_end.drain(..) {
+                    payload.extend(build_subpacket_event_end(
+                        sub_seq, unique_no, act_index, event_num, 0,
+                    ));
+                    sub_seq = sub_seq.wrapping_add(1);
+                    let _ = event_tx.send(AgentEvent::EventEnded);
+                }
+
                 if (!user_driven_events || watchdog_fires) && !pending_event_end.is_empty() {
                     for (unique_no, act_index, event_num) in pending_event_end.drain(..) {
                         payload.extend(build_subpacket_event_end(
@@ -2038,6 +2052,22 @@ async fn keepalive_loop(
                                         ));
                                         continue;
                                     }
+
+                                    // The VM can't drive this event. Never show an
+                                    // empty locked dialog — release it right away
+                                    // and tell the player what was skipped.
+                                    auto_event_end.push((unique_no, act_index, event_id));
+                                    let _ = event_tx.send(AgentEvent::ChatLine {
+                                        line: ChatLine {
+                                            channel: ChatChannel::System,
+                                            sender: "client".into(),
+                                            text: format!(
+                                                "[event] cutscene {event_id} auto-skipped (not yet supported)"
+                                            ),
+                                            server_ts: 0,
+                                        },
+                                    });
+                                    continue;
                                 }
                             }
 

--- a/ffxi-client/src/view_native/input.rs
+++ b/ffxi-client/src/view_native/input.rs
@@ -7,6 +7,13 @@ use bevy::prelude::*;
 use bevy::window::WindowCloseRequested;
 
 #[derive(SystemParam)]
+pub struct StanceParams<'w> {
+    pub rest_stance: ResMut<'w, ffxi_viewer_core::combat_stance::RestStance>,
+    pub walk_mode: Res<'w, ffxi_viewer_core::combat_stance::WalkMode>,
+    pub move_intent: ResMut<'w, ffxi_viewer_core::combat_stance::SelfMoveIntent>,
+}
+
+#[derive(SystemParam)]
 pub struct CameraInputParams<'w> {
     pub mode: ResMut<'w, CameraMode>,
     pub chase: ResMut<'w, ChaseCamera>,
@@ -397,9 +404,15 @@ pub fn dispatch_movement_system(
     mut prediction: ResMut<LocalPlayerPrediction>,
     navmesh: Res<super::navmesh_overlay::NavmeshState>,
     minimap_hover: Res<ffxi_viewer_core::minimap::input::MinimapHoverGate>,
-    mut rest_stance: ResMut<ffxi_viewer_core::combat_stance::RestStance>,
-    walk_mode: Res<ffxi_viewer_core::combat_stance::WalkMode>,
+    mut stance: StanceParams,
 ) {
+    let rest_stance = &mut stance.rest_stance;
+    let walk_mode = &stance.walk_mode;
+    let move_intent = &mut stance.move_intent;
+    // Cleared every tick; the movement branch below re-asserts it while keys
+    // are actually held, so every early return reads as "stopped".
+    **move_intent = ffxi_viewer_core::combat_stance::SelfMoveIntent::default();
+
     if matches!(*mode, InputMode::Chat(_) | InputMode::Dialog(_)) {
         autorun.phantom_forward = false;
         autorun.strafe_held_since = None;
@@ -632,6 +645,12 @@ pub fn dispatch_movement_system(
         }
         return;
     }
+
+    **move_intent = ffxi_viewer_core::combat_stance::SelfMoveIntent {
+        moving: forward != 0 || strafe != 0 || turn_in_chase,
+        forward: forward.signum() as i8,
+        strafe: strafe.signum() as i8,
+    };
 
     let mut heading = self_pos.heading;
     if forward != 0 {

--- a/ffxi-event/src/vm.rs
+++ b/ffxi-event/src/vm.rs
@@ -55,6 +55,10 @@ const OP_EXECEND: u8 = 0x21;
 const OP_MESWAIT: u8 = 0x23;
 const OP_QUERY: u8 = 0x24;
 const OP_QUERYWAIT: u8 = 0x25;
+const OP_REQSET: u8 = 0x27;
+const OP_REQSET_CHECKED: u8 = 0x28;
+const OP_REQSET_PRIORITY: u8 = 0x29;
+const OP_REQWAIT: u8 = 0x2A;
 const OP_SETBITWORK: u8 = 0x40;
 const OP_GETBITWORK: u8 = 0x41;
 const OP_SENDTAG: u8 = 0x43;
@@ -253,6 +257,17 @@ impl EventVm {
                     }
                     self.exec_pointer += 1;
                 }
+                // XiEvent ReqSet/GetReqStatus family: ask an actor to play a
+                // motion tag and wait for it to finish. This dialog-only VM has
+                // no actor choreography, so every request completes instantly —
+                // skip by documented size (research/XiEvents/OpCodes/0x0027.md
+                // through 0x002A.md). Sizes: 0x27/0x28/0x29 = 7, 0x2A = 6.
+                OP_REQSET | OP_REQSET_CHECKED | OP_REQSET_PRIORITY => {
+                    self.exec_pointer += 7;
+                }
+                OP_REQWAIT => {
+                    self.exec_pointer += 6;
+                }
                 _ => {
                     let meta = OPCODE_META.get(op as usize).copied();
                     match meta {
@@ -412,6 +427,30 @@ mod tests {
         let mut e = vm(vec![OP_GOTO, 4, 0, 0xFF, OP_END], vec![]);
         assert_eq!(e.step(), StepResult::Done);
         assert_eq!(e.exec_pointer(), 4);
+    }
+
+    #[test]
+    fn reqset_family_skips_by_size_and_continues() {
+        // The ReqSet/GetReqStatus opcodes are actor-choreography sync points with
+        // no dialog effect; a stalled dialog script must step past them (size 7 for
+        // 0x27/0x28/0x29, size 6 for 0x2A) and reach END rather than Unimplemented.
+        for (op, size) in [
+            (OP_REQSET, 7usize),
+            (OP_REQSET_CHECKED, 7),
+            (OP_REQSET_PRIORITY, 7),
+            (OP_REQWAIT, 6),
+        ] {
+            let mut data = vec![op];
+            data.extend(std::iter::repeat_n(0u8, size - 1)); // operand padding
+            data.push(OP_END);
+            let mut e = vm(data, vec![]);
+            assert_eq!(
+                e.step(),
+                StepResult::Done,
+                "op 0x{op:02X} should run to END"
+            );
+            assert_eq!(e.exec_pointer(), size, "op 0x{op:02X} advanced wrong size");
+        }
     }
 
     #[test]

--- a/ffxi-proto/src/decode.rs
+++ b/ffxi-proto/src/decode.rs
@@ -450,11 +450,15 @@ pub struct CharStatus {
     /// Only meaningful while `server_status == animation::FISHING_START`. 0 if the packet
     /// was truncated before this field.
     pub fishing_timer: u8,
+    /// Movement speed (LSB `char_status.cpp` Flags1.Speed, 12 bits). Probed
+    /// live: GM `!speed 120` flips the u16 at +0x28 from 0x0032 to 0x0078.
+    pub speed: u16,
 }
 
 impl CharStatus {
     pub const UNIQUE_NO_OFFSET: usize = 0x20;
     pub const FLAGS0_OFFSET: usize = 0x24;
+    pub const SPEED_OFFSET: usize = 0x28;
     pub const SERVER_STATUS_OFFSET: usize = 0x2C;
     pub const DEAD_COUNTER1_OFFSET: usize = 0x38;
     pub const DEAD_COUNTER2_OFFSET: usize = 0x3C;
@@ -475,6 +479,8 @@ impl CharStatus {
             dead_counter2: rd(Self::DEAD_COUNTER2_OFFSET),
             server_status: body[Self::SERVER_STATUS_OFFSET],
             fishing_timer: body.get(Self::FISHING_TIMER_OFFSET).copied().unwrap_or(0),
+            speed: u16::from_le_bytes([body[Self::SPEED_OFFSET], body[Self::SPEED_OFFSET + 1]])
+                & 0x0FFF,
         })
     }
 
@@ -2279,6 +2285,7 @@ mod tests {
                 dead_counter2: 0,
                 server_status: 0,
                 fishing_timer: 0,
+                speed: 0,
             }
             .seconds_until_homepoint()
         };
@@ -2305,6 +2312,24 @@ mod tests {
             CharStatus::decode(&buf),
             Err(DecodeError::Truncated(n, have)) if n == need && have == need - 1
         ));
+    }
+
+    #[test]
+    fn char_status_decodes_speed_and_masks_high_nibble() {
+        let mut body = vec![0u8; CharStatus::DEAD_COUNTER2_OFFSET + 4];
+        // GM `!speed 120` sets Flags1.Speed (12 bits) at +0x28. The upper nibble
+        // holds unrelated flags and must be masked off.
+        body[CharStatus::SPEED_OFFSET..CharStatus::SPEED_OFFSET + 2]
+            .copy_from_slice(&0xA078u16.to_le_bytes());
+        assert_eq!(CharStatus::decode(&body).unwrap().speed, 0x078);
+    }
+
+    #[test]
+    fn char_status_base_speed_decodes() {
+        let mut body = vec![0u8; CharStatus::DEAD_COUNTER2_OFFSET + 4];
+        body[CharStatus::SPEED_OFFSET..CharStatus::SPEED_OFFSET + 2]
+            .copy_from_slice(&0x0032u16.to_le_bytes());
+        assert_eq!(CharStatus::decode(&body).unwrap().speed, 50);
     }
 }
 

--- a/ffxi-viewer-core/src/combat_stance.rs
+++ b/ffxi-viewer-core/src/combat_stance.rs
@@ -137,6 +137,20 @@ impl WalkMode {
     }
 }
 
+/// The self character's movement input this tick, written by the client's
+/// movement dispatch. The self pose reads this instead of inferring motion from
+/// transform deltas: prediction reconcile keeps nudging the rendered transform,
+/// so inferred speed can hover above `MOVE_EXIT` and hold the run cycle after
+/// the keys are released.
+#[derive(Resource, Default, Debug, Clone, Copy, Eq, PartialEq)]
+pub struct SelfMoveIntent {
+    pub moving: bool,
+    /// -1 backpedal, 0 none, 1 forward.
+    pub forward: i8,
+    /// -1 left, 0 none, 1 right.
+    pub strafe: i8,
+}
+
 pub fn directional_anim_for_skel(skel_file_id: u32, prefix: &[u8; 3]) -> Option<Arc<Mo2Animation>> {
     let map = DIRECTIONAL_ANIMS.get_or_init(|| Mutex::new(HashMap::new()));
     let mut guard = map.lock().ok()?;

--- a/ffxi-viewer-core/src/ffxi_actor_render.rs
+++ b/ffxi-viewer-core/src/ffxi_actor_render.rs
@@ -1853,6 +1853,7 @@ pub fn tick_live_ffxi_actors(
     motion: Res<combat_stance::EntityMotion>,
     rest: Res<combat_stance::RestStance>,
     walk_mode: Res<combat_stance::WalkMode>,
+    self_move: Res<combat_stance::SelfMoveIntent>,
     mut materials: ResMut<Assets<FfxiSkinnedMaterial>>,
     target: Res<crate::scene::Target>,
     mut q_actors: Query<(&mut FfxiRenderActor, &GlobalTransform)>,
@@ -2033,7 +2034,14 @@ pub fn tick_live_ffxi_actors(
 
         actor.facing_dir = 0.0;
         actor.inputs = ActorAnimInputs {
-            moving: motion.is_moving(world_id),
+            // Self motion comes from real input intent: the prediction
+            // reconcile nudges the rendered transform enough to keep inferred
+            // speed above MOVE_EXIT, which held the run cycle after stopping.
+            moving: if is_self {
+                self_move.moving
+            } else {
+                motion.is_moving(world_id)
+            },
             walking,
             forward_vel,
             strafe_vel,

--- a/ffxi-viewer-core/src/lib.rs
+++ b/ffxi-viewer-core/src/lib.rs
@@ -312,6 +312,7 @@ impl<S: SceneSource + Resource> Plugin for ViewerCorePlugin<S> {
         app.init_resource::<combat_stance::RestStance>();
         app.init_resource::<combat_stance::AnimationBlends>();
         app.init_resource::<combat_stance::WalkMode>();
+        app.init_resource::<combat_stance::SelfMoveIntent>();
         app.init_resource::<camera::CameraTransition>();
 
         #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
Three independent client bug fixes found while playing against a local LandSandBoat server (macOS, Apple Silicon). Each is verified end-to-end; no dependencies between them, happy to split if you'd prefer separate PRs. Opening as **draft** for your read on approach.

## 1. NPC dialogs stall on the ReqSet opcode family + undriveable events pin the player

**Symptom:** talking to many NPCs did nothing visible, and left the character stuck `InEvent` server-side — blocking movement, zoning, and logout.

**Cause:** the event VM stopped (`StepResult::Unimplemented`) on opcode 0x29 (and siblings 0x27/0x28/0x2A), so `DialogSession::begin` returned `None` and the client fell back to an empty locked dialog. These are the `XiEvent` ReqSet/GetReqStatus family — actor-choreography sync points (play a motion, wait for it). A dialog-only VM has no choreography, so they should complete instantly.

**Fix:**
- `ffxi-event`: implement 0x27/0x28/0x29 (size 7) and 0x2A (size 6) as instantly-complete no-ops, advancing the exec pointer by their documented size (research/XiEvents/OpCodes/0x0027.md–0x002A.md). Real dialog scripts now reach their MESSAG/PROMPT opcodes.
- `ffxi-client`: when `begin()` still can't drive an event (some other unimplemented opcode, or missing DAT), send `EVENT_END` on the next tick and print a chat notice instead of pinning the character behind an empty dialog.

**Tests:** `vm.rs` unit test asserting the ReqSet family skips by documented size and runs to END rather than `Unimplemented`.

**Verified:** against retail DATs on a local LSB — Northern San d'Oria / Letterare / event 660 previously stopped on 0x29, now yields its full dialog text and ends cleanly with no `InEvent` residue.

**Scope note:** ReqSet was the family blocking the NPCs I hit, but VM opcode coverage is still partial — other NPCs may stop on a different unimplemented opcode. Those now auto-release with a notice instead of locking, so partial coverage degrades gracefully rather than trapping the player.

## 2. Self run animation persists after movement stops

**Symptom:** stop moving → the player keeps the run cycle instead of returning to idle.

**Cause:** the self pose read `EntityMotion` smoothed velocity, inferred from rendered-transform deltas. The local-player prediction reconcile keeps micro-nudging the self transform, so inferred speed can hover above `MOVE_EXIT` and hold the run cycle indefinitely. Only the self is reconciled, which matches the bug hitting the player and not observed entities.

**Fix:** drive the self `moving` pose from real input intent (`SelfMoveIntent`, written by the movement dispatch each tick) instead of inferred motion. Observed entities keep the transform-based inference (their positions aren't reconciled). Stance resources are grouped into a `StanceParams` `SystemParam` to stay under Bevy's system-parameter limit.

## 3. GM `!speed` / status speed changes don't apply to local movement

**Symptom:** `!speed 120` returns "New speed: 120" but the player keeps moving at base speed.

**Cause:** self movement speed arrives in the 0x037 CHAR_STATUS packet (char_status.cpp `Flags1.Speed`, a 12-bit field), which the client decoded but never read for speed — it only synced speed from position packets.

**Fix:** decode the 12-bit speed at CHAR_STATUS +0x28 and sync it into `self_pos` so the prediction step uses the server's speed mid-session. Zero from a partial packet is ignored. Byte offset confirmed by live probe (`!speed 120` flips the u16 at +0x28 from 0x0032 to 0x0078).

**Tests:** `decode.rs` unit tests for the 12-bit speed field (base 50, and `!speed` value with the high nibble masked off).

**Verified:** headless against local LSB — `position_changed` speed follows 50 → 120 across a `!speed 120`.

## Testing

- `cargo build --release` across ffxi-client / ffxi-event / ffxi-proto / ffxi-viewer-core — clean.
- `cargo test -p ffxi-event -p ffxi-proto` — 173 passed (3 new: ReqSet skip, speed decode ×2).
- `cargo fmt --check` — clean.
- Manual + headless end-to-end for each fix against a local LandSandBoat server.

https://claude.ai/code/session_015dpGADWJkWoGf5wvG3zdje