### PR TITLE
fix(build): stop forcing macOS-only CXXFLAGS on every platform

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,30 +1,14 @@
 # Workspace-local cargo config.
 #
-# ## CXXFLAGS workaround for `recastnavigation-rs` build (macOS)
+# NOTE: a `[env] CXXFLAGS = "-isysroot /Library/Developer/CommandLineTools/..."`
+# block used to live here as a workaround for a stale macOS Command Line Tools
+# layout on one developer's machine (see git history). Cargo's `[env]` table
+# is global — it can't be scoped to a target triple — so it silently broke
+# `cxx`/`recastnavigation-rs` builds on every non-macOS platform (Linux,
+# Steam Deck, Windows) by pointing every C++ compile at a macOS-only sysroot.
+# Removed; that fix belongs in the affected developer's personal
+# `~/.cargo/config.toml`, not this shared, cross-platform config.
 #
-# `recastnavigation-rs` (used by `ffxi-nav-recast`) is a `cxx`-bridged
-# Rust binding to the C++ Recast/Detour library. On macOS it requires a
-# functioning Apple Clang + libc++ install.
-#
-# On at least one developer machine, the Command Line Tools install has
-# a stale layout where clang's first C++ search path
-# (`/Library/Developer/CommandLineTools/usr/include/c++/v1/`) is empty,
-# while the actual headers live in the SDK at
-# `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/`.
-# Without this `-isystem`, cxx-build fails with `'algorithm' file not found`.
-#
-# The proper fix is to reinstall Command Line Tools:
-#     sudo rm -rf /Library/Developer/CommandLineTools
-#     xcode-select --install
-# After which this `[env]` block can be removed.
-#
-# `MACOSX_DEPLOYMENT_TARGET` is pinned because some `cxx` versions emit a
-# default that targets the *current* macOS, which on bleeding-edge macOS
-# (e.g. 26.x) is past what the Recast C++ source has been verified
-# against. 14.0 is a safe modern floor.
-[env]
-CXXFLAGS = "-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -isystem /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1"
-
 # ## Build-speed tuning
 #
 # Enables the per-profile `codegen-backend` key used by [profile.dev] in the


### PR DESCRIPTION
## Summary
- .cargo/config.toml set `[env] CXXFLAGS` unconditionally to a Command-Line-Tools-only isysroot path meant as a workaround for one developer's macOS machine.
- Cargo's `[env]` table is global (no per-target scoping), so this silently broke the `cxx`/`recastnavigation-rs` build on every non-macOS platform: the system c++ compiler got pointed at a nonexistent sysroot and could not even find its own standard headers (`bits/wordsize.h`), failing before `ffxi-client` could build at all.
- Removed the block; per its own comment this workaround was meant to be temporary (fixed by reinstalling Command Line Tools) and never should have lived in shared, cross-platform config.

## Test plan
- [x] Built `ffxi-client --features native-window` from a clean `cargo build` on native Linux (Fedora toolbox on a Steam Deck / Bazzite host) — previously failed with `bits/wordsize.h: No such file or directory` in the `cxx` build script, now succeeds.
- [x] Ran the built binary: correctly detected the AMD Custom GPU 0932 (RADV VANGOGH, the Steam Deck APU) and a Steam Deck gamepad, created its window, no panics.
- [x] Full protocol smoke test against a live LandSandBoat server: `create-char` (account + character creation) and `play --headless` (auth login -> lobby char-list -> character select -> map handoff -> UDP zone-in) all completed successfully, reaching the `in_zone` stage with `blowfish_status: accepted`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)