### PR TITLE
feat(deck): gamepad navigation, movement/camera, and on-screen keyboard support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,30 +1,14 @@
 # Workspace-local cargo config.
 #
-# ## CXXFLAGS workaround for `recastnavigation-rs` build (macOS)
+# NOTE: a `[env] CXXFLAGS = "-isysroot /Library/Developer/CommandLineTools/..."`
+# block used to live here as a workaround for a stale macOS Command Line Tools
+# layout on one developer's machine (see git history). Cargo's `[env]` table
+# is global — it can't be scoped to a target triple — so it silently broke
+# `cxx`/`recastnavigation-rs` builds on every non-macOS platform (Linux,
+# Steam Deck, Windows) by pointing every C++ compile at a macOS-only sysroot.
+# Removed; that fix belongs in the affected developer's personal
+# `~/.cargo/config.toml`, not this shared, cross-platform config.
 #
-# `recastnavigation-rs` (used by `ffxi-nav-recast`) is a `cxx`-bridged
-# Rust binding to the C++ Recast/Detour library. On macOS it requires a
-# functioning Apple Clang + libc++ install.
-#
-# On at least one developer machine, the Command Line Tools install has
-# a stale layout where clang's first C++ search path
-# (`/Library/Developer/CommandLineTools/usr/include/c++/v1/`) is empty,
-# while the actual headers live in the SDK at
-# `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/`.
-# Without this `-isystem`, cxx-build fails with `'algorithm' file not found`.
-#
-# The proper fix is to reinstall Command Line Tools:
-#     sudo rm -rf /Library/Developer/CommandLineTools
-#     xcode-select --install
-# After which this `[env]` block can be removed.
-#
-# `MACOSX_DEPLOYMENT_TARGET` is pinned because some `cxx` versions emit a
-# default that targets the *current* macOS, which on bleeding-edge macOS
-# (e.g. 26.x) is past what the Recast C++ source has been verified
-# against. 14.0 is a safe modern floor.
-[env]
-CXXFLAGS = "-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -isystem /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1"
-
 # ## Build-speed tuning
 #
 # Enables the per-profile `codegen-backend` key used by [profile.dev] in the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.60.2",
+ "wl-clipboard-rs",
  "x11rb",
 ]
 
@@ -2099,7 +2100,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -4755,6 +4756,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5218,6 +5228,16 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -6929,6 +6949,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8266,6 +8297,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3068,6 +3068,7 @@ dependencies = [
  "mac_address",
  "mysql_async",
  "postcard",
+ "rand 0.9.4",
  "rfd",
  "rustls",
  "rustls-pki-types",

--- a/ffxi-client/Cargo.toml
+++ b/ffxi-client/Cargo.toml
@@ -83,6 +83,10 @@ clap.workspace = true
 # distinct from the JSON flavor's anyhow! bails.
 mac_address = "1"
 thiserror = "2"
+# Generates the map-server session key (key3) fresh per login attempt; it
+# must never repeat across connections (LSB stores it verbatim as
+# accounts_sessions.session_key and keys map-server session lookups off it).
+rand = "0.9"
 # Native per-platform user config dir (macOS ~/Library/Application Support,
 # Windows %APPDATA%\Roaming, Linux $XDG_CONFIG_HOME else ~/.config) for the
 # launcher/graphics/keybinds/goal stores. Wraps the OS APIs and applies the XDG

--- a/ffxi-client/Cargo.toml
+++ b/ffxi-client/Cargo.toml
@@ -135,7 +135,9 @@ bevy_framepace = { version = "0.21", optional = true, default-features = false }
 # System clipboard. Used by `/copy` to push recent system-toast lines to
 # the OS clipboard. Optional + gated on `native-window` because the
 # headless/relay binary has no GUI session and no clipboard to write to.
-arboard = { version = "3", optional = true, default-features = false }
+arboard = { version = "3", optional = true, default-features = false, features = [
+    "wayland-data-control",
+] }
 # Native folder picker for the launcher Settings screen (FFXI_DAT_PATH /
 # FFXI_NAVMESH_DIR "Browse…" buttons). On Linux we deliberately select the
 # `xdg-portal` backend instead of rfd's default `gtk3` so the Steam Deck

--- a/ffxi-client/src/config_dir.rs
+++ b/ffxi-client/src/config_dir.rs
@@ -10,6 +10,12 @@ pub fn config_file(name: &str) -> Result<PathBuf> {
     Ok(base.join(APP_DIR).join(name))
 }
 
+pub fn log_file(name: &str) -> Result<PathBuf> {
+    let base =
+        dirs::cache_dir().ok_or_else(|| anyhow!("could not resolve a user cache directory"))?;
+    Ok(base.join(APP_DIR).join("logs").join(name))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -18,5 +24,11 @@ mod tests {
     fn config_file_uses_player_facing_dir() {
         let p = config_file("launcher.json").unwrap();
         assert!(p.ends_with("kuluu/launcher.json"), "got {}", p.display());
+    }
+
+    #[test]
+    fn log_file_uses_player_facing_dir() {
+        let p = log_file("client.log").unwrap();
+        assert!(p.ends_with("kuluu/logs/client.log"), "got {}", p.display());
     }
 }

--- a/ffxi-client/src/launcher.rs
+++ b/ffxi-client/src/launcher.rs
@@ -1,6 +1,7 @@
 use std::io::{self, BufRead, Write};
 
 use anyhow::{anyhow, bail, Result};
+use rand::Rng;
 
 use ffxi_client::auth_client::{AuthClient, AuthSession};
 use ffxi_client::lobby_client::{CharSlot, LobbyClient};
@@ -59,10 +60,13 @@ pub async fn run(
         None => character_menu(handle.chars())?,
     };
 
+    // Must be fresh per login attempt: LSB stores this verbatim as
+    // accounts_sessions.session_key (src/login/data_session.cpp) and the map
+    // server keys its session/blowfish lookup off it — a repeated key3 can
+    // collide with a stale row from an earlier attempt that was never
+    // cleaned up, silently breaking the new connection.
     let mut key3 = [0u8; 20];
-    for (i, b) in key3.iter_mut().enumerate() {
-        *b = ((i as u8).wrapping_mul(0x37)) ^ 0x5a;
-    }
+    rand::rng().fill(&mut key3);
     let handoff = handle
         .select(slot.char_id, &slot.name, key3)
         .await

--- a/ffxi-client/src/lobby_client.rs
+++ b/ffxi-client/src/lobby_client.rs
@@ -721,6 +721,23 @@ async fn read_lpkt_next_login(
     let server_ip = u32::from_le_bytes(buf[56..60].try_into().unwrap());
     let server_port = u32::from_le_bytes(buf[60..64].try_into().unwrap()) as u16;
 
+    // A zeroed IP/port means our fixed-offset parse of lpkt_next_login landed
+    // on the wrong bytes (or the server genuinely sent garbage) — bootstrap
+    // would otherwise silently target 0.0.0.0:0 and every subsequent map
+    // packet would vanish with zero indication why.
+    if server_ip == 0 || server_port == 0 {
+        bail!(
+            "lpkt_next_login: degenerate map handoff (server_ip={server_ip:#010x}, \
+             server_port={server_port}) — response likely misparsed"
+        );
+    }
+
+    tracing::info!(
+        server_ip = %std::net::Ipv4Addr::from(server_ip.to_le_bytes()),
+        server_port,
+        "lobby: handoff resolved map-server address"
+    );
+
     Ok(MapHandoff {
         char_id,
         character_name,

--- a/ffxi-client/src/main.rs
+++ b/ffxi-client/src/main.rs
@@ -18,6 +18,7 @@ mod view_native;
 
 use anyhow::{self, bail, Context, Result};
 use clap::{Parser, Subcommand};
+use rand::Rng;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -294,10 +295,15 @@ async fn run_command_async(args: Args, auth: auth_client::AuthClient) -> Result<
                                         .collect::<Vec<_>>()
                                 )
                             })?;
+                        // Must be fresh per login attempt: LSB stores this
+                        // verbatim as accounts_sessions.session_key
+                        // (src/login/data_session.cpp) and the map server
+                        // keys its session/blowfish lookup off it — a
+                        // repeated key3 can collide with a stale row from an
+                        // earlier attempt that was never cleaned up,
+                        // silently breaking the new connection.
                         let mut key3 = [0u8; 20];
-                        for (i, b) in key3.iter_mut().enumerate() {
-                            *b = ((i as u8).wrapping_mul(0x37)) ^ 0x5a;
-                        }
+                        rand::rng().fill(&mut key3);
                         let handoff = handle
                             .select(slot.char_id, &slot.name, key3)
                             .await

--- a/ffxi-client/src/main.rs
+++ b/ffxi-client/src/main.rs
@@ -132,6 +132,26 @@ fn main() -> Result<()> {
     let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
 
+    // A file sink alongside stderr so a log always exists at a fixed,
+    // discoverable path regardless of how the client was launched (a bare
+    // terminal invocation with no redirect, or a Steam/gamescope entry with
+    // no terminal at all) — stderr-only logging is invisible in both cases.
+    let log_file = ffxi_client::config_dir::log_file("client.log")
+        .ok()
+        .and_then(|path| {
+            path.parent().map(std::fs::create_dir_all);
+            match std::fs::File::create(&path) {
+                Ok(f) => {
+                    eprintln!("logging to {}", path.display());
+                    Some(f)
+                }
+                Err(e) => {
+                    eprintln!("warning: could not open log file {}: {e}", path.display());
+                    None
+                }
+            }
+        });
+
     // Held for the lifetime of main so the chrome layer flushes its
     // trace-<n>.json when the app exits cleanly (close the window / Esc out —
     // a hard kill skips the flush).
@@ -143,15 +163,29 @@ fn main() -> Result<()> {
         tracing_subscriber::registry()
             .with(env_filter)
             .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+            .with(log_file.map(|f| {
+                tracing_subscriber::fmt::layer()
+                    .with_ansi(false)
+                    .with_writer(std::sync::Mutex::new(f))
+            }))
             .with(chrome_layer)
             .init();
         guard
     };
     #[cfg(not(feature = "trace"))]
-    tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .with_env_filter(env_filter)
-        .init();
+    {
+        use tracing_subscriber::layer::SubscriberExt;
+        use tracing_subscriber::util::SubscriberInitExt;
+        tracing_subscriber::registry()
+            .with(env_filter)
+            .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+            .with(log_file.map(|f| {
+                tracing_subscriber::fmt::layer()
+                    .with_ansi(false)
+                    .with_writer(std::sync::Mutex::new(f))
+            }))
+            .init();
+    }
 
     ffxi_client::launcher_store::load().settings.apply_to_env();
 

--- a/ffxi-client/src/map_client.rs
+++ b/ffxi-client/src/map_client.rs
@@ -187,6 +187,12 @@ impl MapClient {
                 sub_opcodes = opcodes.join(" "),
                 "recv"
             );
+        } else {
+            // Distinguishes "received something the server sent that decoded
+            // to zero sub-packets" (bare ack/keepalive) from "received
+            // nothing at all" — the two look identical from the caller's
+            // silence alone, but only one means the map connection is alive.
+            tracing::info!(bytes = n, src = %src, "recv (0 sub-packets)");
         }
 
         Ok(out)

--- a/ffxi-client/src/reactor.rs
+++ b/ffxi-client/src/reactor.rs
@@ -1235,7 +1235,7 @@ mod tests {
             account_id: 0,
             char_id,
             character: "Tester".into(),
-            zone_id: 0,
+            zone_id: Some(0),
         }
     }
 

--- a/ffxi-client/src/scene.rs
+++ b/ffxi-client/src/scene.rs
@@ -214,7 +214,7 @@ mod tests {
             account_id: 1,
             char_id: 42,
             character: "Vanari".into(),
-            zone_id: 230,
+            zone_id: Some(230),
         });
         s.apply_event(&AgentEvent::StageChanged {
             stage: Stage::InZone,
@@ -474,7 +474,7 @@ mod tests {
             account_id: 0,
             char_id: 42,
             character: "Vanari".into(),
-            zone_id: 230,
+            zone_id: Some(230),
         });
         s.apply_event(&AgentEvent::StageChanged {
             stage: Stage::InZone,

--- a/ffxi-client/src/secret_store.rs
+++ b/ffxi-client/src/secret_store.rs
@@ -1,56 +1,68 @@
 use keyring::Entry;
+use tokio::runtime::Handle as RtHandle;
 
 pub struct SecretStore;
 
+/// The Linux `keyring` backend goes through zbus, which panics with "there is
+/// no reactor running" if invoked off-thread from a Tokio reactor. Bevy
+/// systems and observers run on Bevy's own thread, not inside a Tokio task,
+/// so every keyring call must be wrapped in `Handle::block_on` to give zbus
+/// the reactor context it requires.
 impl SecretStore {
-    pub fn get(service: &str, account: &str) -> Option<String> {
-        match Entry::new(service, account) {
-            Ok(entry) => match entry.get_password() {
-                Ok(pw) => Some(pw),
-                Err(keyring::Error::NoEntry) => None,
+    pub fn get(runtime: &RtHandle, service: &str, account: &str) -> Option<String> {
+        runtime.block_on(async {
+            match Entry::new(service, account) {
+                Ok(entry) => match entry.get_password() {
+                    Ok(pw) => Some(pw),
+                    Err(keyring::Error::NoEntry) => None,
+                    Err(e) => {
+                        tracing::warn!(service, account, error = %e, "keyring: get failed");
+                        None
+                    }
+                },
                 Err(e) => {
-                    tracing::warn!(service, account, error = %e, "keyring: get failed");
+                    tracing::warn!(service, account, error = %e, "keyring: open failed");
                     None
                 }
-            },
-            Err(e) => {
-                tracing::warn!(service, account, error = %e, "keyring: open failed");
-                None
             }
-        }
+        })
     }
 
-    pub fn set(service: &str, account: &str, password: &str) -> bool {
-        match Entry::new(service, account) {
-            Ok(entry) => match entry.set_password(password) {
-                Ok(()) => true,
+    pub fn set(runtime: &RtHandle, service: &str, account: &str, password: &str) -> bool {
+        runtime.block_on(async {
+            match Entry::new(service, account) {
+                Ok(entry) => match entry.set_password(password) {
+                    Ok(()) => true,
+                    Err(e) => {
+                        tracing::warn!(service, account, error = %e, "keyring: set failed");
+                        false
+                    }
+                },
                 Err(e) => {
-                    tracing::warn!(service, account, error = %e, "keyring: set failed");
+                    tracing::warn!(service, account, error = %e, "keyring: open failed");
                     false
                 }
-            },
-            Err(e) => {
-                tracing::warn!(service, account, error = %e, "keyring: open failed");
-                false
             }
-        }
+        })
     }
 
-    pub fn delete(service: &str, account: &str) -> bool {
-        match Entry::new(service, account) {
-            Ok(entry) => match entry.delete_credential() {
-                Ok(()) => true,
+    pub fn delete(runtime: &RtHandle, service: &str, account: &str) -> bool {
+        runtime.block_on(async {
+            match Entry::new(service, account) {
+                Ok(entry) => match entry.delete_credential() {
+                    Ok(()) => true,
 
-                Err(keyring::Error::NoEntry) => true,
+                    Err(keyring::Error::NoEntry) => true,
+                    Err(e) => {
+                        tracing::warn!(service, account, error = %e, "keyring: delete failed");
+                        false
+                    }
+                },
                 Err(e) => {
-                    tracing::warn!(service, account, error = %e, "keyring: delete failed");
+                    tracing::warn!(service, account, error = %e, "keyring: open failed");
                     false
                 }
-            },
-            Err(e) => {
-                tracing::warn!(service, account, error = %e, "keyring: open failed");
-                false
             }
-        }
+        })
     }
 }

--- a/ffxi-client/src/session.rs
+++ b/ffxi-client/src/session.rs
@@ -253,7 +253,13 @@ async fn run_map_session(
             account_id: 0,
             char_id: bootstrap.char_id,
             character: bootstrap.char_name.to_string(),
-            zone_id: 0,
+            // The 0x00A LOGIN carrying the real zone hasn't been parsed yet
+            // at handshake time. A hardcoded 0 here used to flash the client
+            // into believing it was in zone 0 (FFXI's meshless "Demonstration
+            // Area") on every supervisor-driven reconnect, even mid-session
+            // in a real zone — None leaves the last-known zone_id untouched
+            // until the real ZoneChanged/LOGIN update arrives.
+            zone_id: None,
         });
     }
     emit_stage(event_tx, Stage::Zoning);
@@ -1443,7 +1449,7 @@ async fn keepalive_loop(
                             account_id: 0,
                             char_id: self_char_id,
                             character: character_name.clone(),
-                            zone_id: current_zone_id,
+                            zone_id: Some(current_zone_id),
                         });
                         let _ = event_tx.send(AgentEvent::StageChanged {
                             stage: Stage::InZone,

--- a/ffxi-client/src/session.rs
+++ b/ffxi-client/src/session.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, bail, Context, Result};
 use ffxi_proto::{decode, framing};
+use rand::Rng;
 use tokio::sync::{broadcast, mpsc};
 
 use crate::auth_client::AuthClient;
@@ -111,10 +112,14 @@ pub async fn run(
 
             emit_stage(&event_tx, Stage::LobbyHandshake);
             let lobby = LobbyClient::new(cfg.server.clone(), cfg.data_port, cfg.view_port);
+            // Must be fresh per login attempt: LSB stores this verbatim as
+            // accounts_sessions.session_key (src/login/data_session.cpp) and
+            // the map server keys its session/blowfish lookup off it — a
+            // repeated key3 can collide with a stale row from an earlier
+            // attempt that was never cleaned up, silently breaking the new
+            // connection.
             let mut key3 = [0u8; 20];
-            for (i, b) in key3.iter_mut().enumerate() {
-                *b = ((i as u8).wrapping_mul(0x37)) ^ 0x5a;
-            }
+            rand::rng().fill(&mut key3);
             let (char_id, handoff) = match &cfg.char_selection {
                 CharSelection::Id(cid) => {
                     let handoff = lobby

--- a/ffxi-client/src/session.rs
+++ b/ffxi-client/src/session.rs
@@ -172,6 +172,20 @@ pub async fn run(
         cli_lang: 0,
     };
 
+    // Only the first 4 bytes: enough to visually confirm key3 differs across
+    // attempts (catching a regression back to the old hardcoded constant)
+    // without logging the full session key.
+    let key3_prefix = key3[..4]
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>();
+    tracing::info!(
+        server_addr = %server_addr,
+        char_id = resolved_char_id,
+        key3_prefix,
+        "resolved map-server bootstrap target"
+    );
+
     let mut current_seed = key3;
     let mut iteration: u32 = 0;
 

--- a/ffxi-client/src/session.rs
+++ b/ffxi-client/src/session.rs
@@ -599,7 +599,16 @@ fn handle_sub_packet(
             }
         }
         op if op == s2c::CHAR_PC || op == s2c::CHAR_NPC => {
-            if let Ok(head) = decode::PosHead::decode(sub.data) {
+            let decoded = decode::PosHead::decode(sub.data);
+            if let Err(ref e) = decoded {
+                tracing::warn!(
+                    op = format!("0x{op:03x}"),
+                    error = %e,
+                    body_len = sub.data.len(),
+                    "CHAR_PC/CHAR_NPC PosHead decode failed"
+                );
+            }
+            if let Ok(head) = decoded {
                 if decode::PosHead::is_entity_despawn(op, sub.data) {
                     claim_cache.remove(&head.unique_no);
                     let _ = event_tx.send(AgentEvent::EntityRemoved { id: head.unique_no });
@@ -636,6 +645,16 @@ fn handle_sub_packet(
                     }
                     kind
                 };
+
+                if op == s2c::CHAR_NPC {
+                    tracing::debug!(
+                        target: "char_npc_arrival",
+                        id = head.unique_no,
+                        act_index = head.act_index,
+                        ?kind,
+                        "CHAR_NPC arrived"
+                    );
+                }
 
                 kind_cache
                     .entry(head.unique_no)

--- a/ffxi-client/src/session.rs
+++ b/ffxi-client/src/session.rs
@@ -1391,6 +1391,12 @@ async fn keepalive_loop(
                 match cmd {
                     None => break,
                     Some(AgentCommand::Move { x, y, z, heading }) => {
+                        tracing::debug!(
+                            target: "agent_move_recv",
+                            pos = format!("({x:.1},{y:.1},{z:.1})"),
+                            heading,
+                            "AgentCommand::Move received"
+                        );
                         self_pos = Position { pos: Vec3 { x, y, z }, heading, ..self_pos };
                         let _ = event_tx.send(AgentEvent::PositionChanged { pos: self_pos });
                     }
@@ -1999,6 +2005,13 @@ async fn keepalive_loop(
                         Some(t) => should_emit_pos(t.elapsed(), pos_delta, heading_changed),
                     };
                 if include_pos {
+                    tracing::debug!(
+                        target: "outbound_pos",
+                        pos = format!("({:.1},{:.1},{:.1})", self_pos.pos.x, self_pos.pos.y, self_pos.pos.z),
+                        heading = self_pos.heading,
+                        pos_delta,
+                        "sent 0x015 POS"
+                    );
                     payload.extend(build_subpacket_pos(
                         sub_seq,
                         self_pos.pos.x,

--- a/ffxi-client/src/session.rs
+++ b/ffxi-client/src/session.rs
@@ -249,8 +249,19 @@ async fn run_map_session(
     cmd_rx: &mut mpsc::Receiver<AgentCommand>,
     event_tx: &broadcast::Sender<AgentEvent>,
 ) -> Result<MapOutcome> {
+    tracing::info!(
+        iteration,
+        server_addr = %map.server_addr(),
+        char_id = bootstrap.char_id,
+        "sending map-server bootstrap (1/2)"
+    );
     map.send_bootstrap(bootstrap).await?;
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    tracing::info!(
+        iteration,
+        server_addr = %map.server_addr(),
+        "sending map-server bootstrap (2/2)"
+    );
     map.send_bootstrap(bootstrap).await?;
 
     if iteration == 1 {
@@ -324,10 +335,23 @@ async fn run_map_session(
                 }
             }
 
-            Ok(Err(_)) => break,
+            Ok(Err(e)) => {
+                tracing::warn!(
+                    iteration,
+                    error = %e,
+                    "zone-in flood: recv_decrypted failed, aborting flood early"
+                );
+                break;
+            }
 
             Err(_elapsed) => {
                 if should_break_flood(self_pos_seeded) {
+                    tracing::warn!(
+                        iteration,
+                        total_subs,
+                        "zone-in flood: 500ms recv timeout with no self-position seed, \
+                         aborting flood early"
+                    );
                     break;
                 }
             }

--- a/ffxi-client/src/state.rs
+++ b/ffxi-client/src/state.rs
@@ -572,7 +572,9 @@ impl SessionState {
                 self.account_id = Some(*account_id);
                 self.char_id = Some(*char_id);
                 self.character = Some(character.clone());
-                self.zone_id = Some(*zone_id);
+                if let Some(z) = zone_id {
+                    self.zone_id = Some(*z);
+                }
             }
             AgentEvent::StageChanged { stage } => {
                 self.stage = *stage;
@@ -951,7 +953,13 @@ pub enum AgentEvent {
         account_id: u32,
         char_id: u32,
         character: String,
-        zone_id: u16,
+        /// `None` means the zone isn't known yet at handshake time (the
+        /// server's 0x00A LOGIN hasn't been parsed) — leaves the existing
+        /// `zone_id` untouched rather than stomping it with a placeholder.
+        /// A hardcoded `0` here previously flashed the client into believing
+        /// it was in FFXI's meshless "Demonstration Area" on every
+        /// supervisor-driven reconnect, even mid-session in a real zone.
+        zone_id: Option<u16>,
     },
     StageChanged {
         stage: Stage,
@@ -1884,7 +1892,7 @@ mod tests {
             account_id: 42,
             char_id: 7,
             character: "Tester".into(),
-            zone_id: 100,
+            zone_id: Some(100),
         });
         assert_eq!(s.account_id, Some(42));
         assert_eq!(s.char_id, Some(7));
@@ -2423,7 +2431,7 @@ mod tests {
             account_id: 1,
             char_id: 99,
             character: "Self".into(),
-            zone_id: 230,
+            zone_id: Some(230),
         });
 
         assert!(s.self_position().is_none());

--- a/ffxi-client/src/supervisor.rs
+++ b/ffxi-client/src/supervisor.rs
@@ -33,7 +33,7 @@ impl Default for SupervisorConfig {
 }
 
 pub async fn run(
-    cfg: session::Config,
+    mut cfg: session::Config,
     mut external_cmd_rx: mpsc::Receiver<AgentCommand>,
     event_tx: broadcast::Sender<AgentEvent>,
     sup_cfg: SupervisorConfig,
@@ -65,6 +65,15 @@ pub async fn run(
         let reactor_event_tx = event_tx.clone();
         let reactor_cfg_clone = reactor_cfg;
         let cfg_clone = cfg.clone();
+        // The launcher UI's already-completed auth+lobby handshake (initial_state)
+        // is only valid for this first attempt. Reusing it on a supervisor-driven
+        // reconnect sends the map server a stale, already-consumed key3 that it
+        // can't validate — packets go unrecognized, the map server's own pending
+        // session for this character silently times out after MAX_TIME_LASTUPDATE
+        // (60s, matching our own MAP_SILENCE_TIMEOUT), and the client sits waiting
+        // the whole time for a connection that was never going to complete.
+        // Clearing it here forces every retry to authenticate fresh.
+        cfg.initial_state = None;
         let mut reactor_handle = tokio::spawn(async move {
             reactor::run(cfg_clone, inner_rx, reactor_event_tx, reactor_cfg_clone).await
         });

--- a/ffxi-client/src/view_native/gamepad_input.rs
+++ b/ffxi-client/src/view_native/gamepad_input.rs
@@ -224,7 +224,9 @@ fn synth_bound_key(
 }
 
 /// Face buttons + D-pad-right; combat/targeting ones are gated to
-/// `InputMode::World`, mirroring `handle_input_system`'s own gate.
+/// `InputMode::World` (and not an open trade window, which stays in `World`
+/// mode but must route like a menu), mirroring `handle_input_system`'s own
+/// gate.
 ///
 /// - South: `ConfirmAction` in `World` mode — FFXI's actual "talk to this NPC
 ///   / open the trade-check-invite menu for this target" dispatch (also the
@@ -248,6 +250,7 @@ pub(super) fn gamepad_ingame_action_system(
     gamepads: Query<&Gamepad>,
     bindings: Res<Bindings>,
     mode: Res<InputMode>,
+    trade_state: Res<ffxi_viewer_core::hud::trade::TradeState>,
     mut keys: ResMut<ButtonInput<KeyCode>>,
     mut keyboard_writer: MessageWriter<KeyboardInput>,
     windows: Query<Entity, With<PrimaryWindow>>,
@@ -258,7 +261,11 @@ pub(super) fn gamepad_ingame_action_system(
     let Some(gamepad) = gamepads.iter().next() else {
         return;
     };
-    let in_world = matches!(*mode, InputMode::World);
+    // A trade window doesn't change InputMode (text_input.rs checks
+    // trade_state.open ahead of the InputMode match), so without this it's
+    // treated as World and D-pad/South/East go to combat/target actions
+    // instead of navigating trade slots.
+    let in_world = matches!(*mode, InputMode::World) && !trade_state.open;
 
     if gamepad.just_pressed(GamepadButton::South) {
         if in_world {

--- a/ffxi-client/src/view_native/gamepad_input.rs
+++ b/ffxi-client/src/view_native/gamepad_input.rs
@@ -1,0 +1,160 @@
+use std::collections::HashSet;
+
+use bevy::input::gamepad::{Gamepad, GamepadButton};
+use bevy::input::keyboard::{Key, KeyboardInput};
+use bevy::input::{ButtonInput, ButtonState};
+use bevy::input_focus::tab_navigation::{NavAction, TabNavigation, TabNavigationError};
+use bevy::input_focus::{InputFocus, InputFocusVisible};
+use bevy::prelude::*;
+use bevy::window::PrimaryWindow;
+
+use ffxi_viewer_core::{Action, Bindings};
+
+const STICK_DEADZONE: f32 = 0.35;
+
+#[derive(Resource, Default)]
+pub(super) struct GamepadAxisHeld {
+    held: HashSet<KeyCode>,
+}
+
+fn sync_axis_key(
+    keys: &mut ButtonInput<KeyCode>,
+    held: &mut HashSet<KeyCode>,
+    key: KeyCode,
+    should_hold: bool,
+) {
+    if should_hold {
+        if held.insert(key) {
+            keys.press(key);
+        }
+    } else if held.remove(&key) {
+        keys.release(key);
+    }
+}
+
+fn bound_key(bindings: &Bindings, action: Action) -> Option<KeyCode> {
+    let bind = bindings.get(action)?;
+    if bind.mods != Default::default() {
+        return None;
+    }
+    Some(bind.key)
+}
+
+/// D-pad moves focus between launcher UI widgets (mirrors Tab/Shift+Tab); South
+/// activates the focused widget (mirrors Enter). Both ride the same
+/// `bevy_input_focus`/`bevy_ui_widgets` machinery every launcher_ui screen
+/// already uses for keyboard/mouse, so no per-screen changes are needed.
+pub(super) fn gamepad_launcher_nav_system(
+    gamepads: Query<&Gamepad>,
+    nav: TabNavigation,
+    mut focus: ResMut<InputFocus>,
+    mut visible: ResMut<InputFocusVisible>,
+    windows: Query<Entity, With<PrimaryWindow>>,
+    mut keyboard_writer: MessageWriter<KeyboardInput>,
+) {
+    let Ok(window) = windows.single() else {
+        return;
+    };
+    for gamepad in &gamepads {
+        let nav_action = if gamepad.just_pressed(GamepadButton::DPadDown)
+            || gamepad.just_pressed(GamepadButton::DPadRight)
+        {
+            Some(NavAction::Next)
+        } else if gamepad.just_pressed(GamepadButton::DPadUp)
+            || gamepad.just_pressed(GamepadButton::DPadLeft)
+        {
+            Some(NavAction::Previous)
+        } else {
+            None
+        };
+        if let Some(action) = nav_action {
+            match nav.navigate(&focus, action) {
+                Ok(next) => {
+                    focus.set(next);
+                    visible.0 = true;
+                }
+                Err(TabNavigationError::NoTabGroupForCurrentFocus { new_focus, .. }) => {
+                    focus.set(new_focus);
+                    visible.0 = true;
+                }
+                Err(_) => {}
+            }
+        }
+
+        if gamepad.just_pressed(GamepadButton::South) {
+            keyboard_writer.write(KeyboardInput {
+                key_code: KeyCode::Enter,
+                logical_key: Key::Enter,
+                state: ButtonState::Pressed,
+                text: None,
+                repeat: false,
+                window,
+            });
+        }
+    }
+}
+
+/// Left stick drives move/strafe, right stick drives camera yaw/pitch, bumpers
+/// zoom. Rather than duplicating `input::handle_input_system` /
+/// `dispatch_movement_system`'s logic, this holds/releases whatever `KeyCode`
+/// is currently bound to each `Action` (respecting rebinding), so both systems
+/// see it exactly as if the bound key were physically held.
+pub(super) fn gamepad_movement_camera_system(
+    gamepads: Query<&Gamepad>,
+    bindings: Res<Bindings>,
+    mut keys: ResMut<ButtonInput<KeyCode>>,
+    mut held: ResMut<GamepadAxisHeld>,
+) {
+    let Some(gamepad) = gamepads.iter().next() else {
+        for key in held.held.drain() {
+            keys.release(key);
+        }
+        return;
+    };
+
+    let left = gamepad.left_stick();
+    let right = gamepad.right_stick();
+
+    if let Some(key) = bound_key(&bindings, Action::MoveForward) {
+        sync_axis_key(&mut keys, &mut held.held, key, left.y > STICK_DEADZONE);
+    }
+    if let Some(key) = bound_key(&bindings, Action::MoveBackward) {
+        sync_axis_key(&mut keys, &mut held.held, key, left.y < -STICK_DEADZONE);
+    }
+    if let Some(key) = bound_key(&bindings, Action::StrafeRight) {
+        sync_axis_key(&mut keys, &mut held.held, key, left.x > STICK_DEADZONE);
+    }
+    if let Some(key) = bound_key(&bindings, Action::StrafeLeft) {
+        sync_axis_key(&mut keys, &mut held.held, key, left.x < -STICK_DEADZONE);
+    }
+
+    if let Some(key) = bound_key(&bindings, Action::CameraYawRight) {
+        sync_axis_key(&mut keys, &mut held.held, key, right.x > STICK_DEADZONE);
+    }
+    if let Some(key) = bound_key(&bindings, Action::CameraYawLeft) {
+        sync_axis_key(&mut keys, &mut held.held, key, right.x < -STICK_DEADZONE);
+    }
+    if let Some(key) = bound_key(&bindings, Action::CameraPitchUp) {
+        sync_axis_key(&mut keys, &mut held.held, key, right.y > STICK_DEADZONE);
+    }
+    if let Some(key) = bound_key(&bindings, Action::CameraPitchDown) {
+        sync_axis_key(&mut keys, &mut held.held, key, right.y < -STICK_DEADZONE);
+    }
+
+    if let Some(key) = bound_key(&bindings, Action::CameraZoomIn) {
+        sync_axis_key(
+            &mut keys,
+            &mut held.held,
+            key,
+            gamepad.pressed(GamepadButton::LeftTrigger),
+        );
+    }
+    if let Some(key) = bound_key(&bindings, Action::CameraZoomOut) {
+        sync_axis_key(
+            &mut keys,
+            &mut held.held,
+            key,
+            gamepad.pressed(GamepadButton::RightTrigger),
+        );
+    }
+}

--- a/ffxi-client/src/view_native/gamepad_input.rs
+++ b/ffxi-client/src/view_native/gamepad_input.rs
@@ -8,7 +8,8 @@ use bevy::input_focus::{InputFocus, InputFocusVisible};
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 
-use ffxi_viewer_core::{Action, Bindings, InputMode, Target};
+use ffxi_viewer_core::hud::death_prompt::is_dead;
+use ffxi_viewer_core::{Action, Bindings, InputMode, SceneState, Target};
 
 const STICK_DEADZONE: f32 = 0.35;
 
@@ -44,6 +45,11 @@ fn bound_key(bindings: &Bindings, action: Action) -> Option<KeyCode> {
 /// activates the focused widget (mirrors Enter). Both ride the same
 /// `bevy_input_focus`/`bevy_ui_widgets` machinery every launcher_ui screen
 /// already uses for keyboard/mouse, so no per-screen changes are needed.
+///
+/// Only the first connected `Gamepad` entity is read: Steam Input can expose
+/// one physical controller as two simultaneous devices (e.g. the Deck's own
+/// pad plus a virtual Xbox-pad mirror it creates for compatibility), and
+/// processing every entity would fire each button press once per device.
 pub(super) fn gamepad_launcher_nav_system(
     gamepads: Query<&Gamepad>,
     nav: TabNavigation,
@@ -55,42 +61,44 @@ pub(super) fn gamepad_launcher_nav_system(
     let Ok(window) = windows.single() else {
         return;
     };
-    for gamepad in &gamepads {
-        let nav_action = if gamepad.just_pressed(GamepadButton::DPadDown)
-            || gamepad.just_pressed(GamepadButton::DPadRight)
-        {
-            Some(NavAction::Next)
-        } else if gamepad.just_pressed(GamepadButton::DPadUp)
-            || gamepad.just_pressed(GamepadButton::DPadLeft)
-        {
-            Some(NavAction::Previous)
-        } else {
-            None
-        };
-        if let Some(action) = nav_action {
-            match nav.navigate(&focus, action) {
-                Ok(next) => {
-                    focus.set(next);
-                    visible.0 = true;
-                }
-                Err(TabNavigationError::NoTabGroupForCurrentFocus { new_focus, .. }) => {
-                    focus.set(new_focus);
-                    visible.0 = true;
-                }
-                Err(_) => {}
-            }
-        }
+    let Some(gamepad) = gamepads.iter().next() else {
+        return;
+    };
 
-        if gamepad.just_pressed(GamepadButton::South) {
-            keyboard_writer.write(KeyboardInput {
-                key_code: KeyCode::Enter,
-                logical_key: Key::Enter,
-                state: ButtonState::Pressed,
-                text: None,
-                repeat: false,
-                window,
-            });
+    let nav_action = if gamepad.just_pressed(GamepadButton::DPadDown)
+        || gamepad.just_pressed(GamepadButton::DPadRight)
+    {
+        Some(NavAction::Next)
+    } else if gamepad.just_pressed(GamepadButton::DPadUp)
+        || gamepad.just_pressed(GamepadButton::DPadLeft)
+    {
+        Some(NavAction::Previous)
+    } else {
+        None
+    };
+    if let Some(action) = nav_action {
+        match nav.navigate(&focus, action) {
+            Ok(next) => {
+                focus.set(next);
+                visible.0 = true;
+            }
+            Err(TabNavigationError::NoTabGroupForCurrentFocus { new_focus, .. }) => {
+                focus.set(new_focus);
+                visible.0 = true;
+            }
+            Err(_) => {}
         }
+    }
+
+    if gamepad.just_pressed(GamepadButton::South) {
+        keyboard_writer.write(KeyboardInput {
+            key_code: KeyCode::Enter,
+            logical_key: Key::Enter,
+            state: ButtonState::Pressed,
+            text: None,
+            repeat: false,
+            window,
+        });
     }
 }
 
@@ -159,14 +167,30 @@ pub(super) fn gamepad_movement_camera_system(
     }
 }
 
-fn synth_nav_key(writer: &mut MessageWriter<KeyboardInput>, window: Entity, key_code: KeyCode) {
-    let logical_key = match key_code {
+/// Mirrors `keybinds::nav_keycode_for`'s reverse direction (private to that
+/// module), for the same fixed key set `Bindings::matches_logical` accepts.
+fn logical_key_for(key_code: KeyCode) -> Key {
+    match key_code {
         KeyCode::Escape => Key::Escape,
+        KeyCode::Backspace => Key::Backspace,
+        KeyCode::Tab => Key::Tab,
+        KeyCode::Space => Key::Space,
+        KeyCode::ArrowUp => Key::ArrowUp,
+        KeyCode::ArrowDown => Key::ArrowDown,
+        KeyCode::ArrowLeft => Key::ArrowLeft,
+        KeyCode::ArrowRight => Key::ArrowRight,
+        KeyCode::PageUp => Key::PageUp,
+        KeyCode::PageDown => Key::PageDown,
+        KeyCode::Home => Key::Home,
+        KeyCode::End => Key::End,
         _ => Key::Enter,
-    };
+    }
+}
+
+fn synth_nav_key(writer: &mut MessageWriter<KeyboardInput>, window: Entity, key_code: KeyCode) {
     writer.write(KeyboardInput {
         key_code,
-        logical_key,
+        logical_key: logical_key_for(key_code),
         state: ButtonState::Pressed,
         text: None,
         repeat: false,
@@ -174,20 +198,26 @@ fn synth_nav_key(writer: &mut MessageWriter<KeyboardInput>, window: Entity, key_
     });
 }
 
-/// South is a single context-sensitive action button: whenever `InputMode`
-/// isn't `World` (a menu, dialog, or other overlay is open) it mirrors
-/// `NavConfirm` (Enter), exactly like `gamepad_launcher_nav_system` does for
-/// the launcher. In `World` mode it mirrors `ToggleEngage` if a target is
-/// selected, otherwise `OpenMenu` — matching `handle_input_system`'s own
+/// South is a single context-sensitive action button. While the death prompt
+/// is up it mirrors `ConfirmAction` (the /return-home dispatch text_input.rs
+/// intercepts before generic World-mode handling); otherwise, whenever
+/// `InputMode` isn't `World` (a menu, dialog, or other overlay is open) it
+/// mirrors `NavConfirm`, exactly like `gamepad_launcher_nav_system` does for
+/// the launcher. In plain `World` mode it mirrors `ToggleEngage` if a target
+/// is selected, otherwise `OpenMenu` — matching `handle_input_system`'s own
 /// `InputMode::World` gating, so the two can never both fire off one press
 /// the way a raw keyboard-emulated `F` from Steam Input's Desktop profile
-/// could. East mirrors `NavCancel` (Escape) so a menu opened this way can
-/// also be closed with the gamepad.
+/// could. East mirrors `NavCancel` so a menu opened this way can also be
+/// closed with the gamepad.
+///
+/// Only the first connected `Gamepad` entity is read — see the doc comment
+/// on `gamepad_launcher_nav_system` for why.
 pub(super) fn gamepad_ingame_action_system(
     gamepads: Query<&Gamepad>,
     bindings: Res<Bindings>,
     mode: Res<InputMode>,
     target: Res<Target>,
+    scene_state: Res<SceneState>,
     mut keys: ResMut<ButtonInput<KeyCode>>,
     mut keyboard_writer: MessageWriter<KeyboardInput>,
     windows: Query<Entity, With<PrimaryWindow>>,
@@ -195,25 +225,33 @@ pub(super) fn gamepad_ingame_action_system(
     let Ok(window) = windows.single() else {
         return;
     };
-    for gamepad in &gamepads {
-        if gamepad.just_pressed(GamepadButton::South) {
-            if matches!(*mode, InputMode::World) {
-                let action = if target.id.is_some() {
-                    Action::ToggleEngage
-                } else {
-                    Action::OpenMenu
-                };
-                if let Some(key) = bound_key(&bindings, action) {
-                    keys.press(key);
-                    keys.release(key);
-                }
-            } else {
-                synth_nav_key(&mut keyboard_writer, window, KeyCode::Enter);
-            }
-        }
+    let Some(gamepad) = gamepads.iter().next() else {
+        return;
+    };
 
-        if gamepad.just_pressed(GamepadButton::East) && !matches!(*mode, InputMode::World) {
-            synth_nav_key(&mut keyboard_writer, window, KeyCode::Escape);
+    if gamepad.just_pressed(GamepadButton::South) {
+        if matches!(*mode, InputMode::World) && is_dead(&scene_state) {
+            if let Some(key) = bound_key(&bindings, Action::ConfirmAction) {
+                synth_nav_key(&mut keyboard_writer, window, key);
+            }
+        } else if matches!(*mode, InputMode::World) {
+            let action = if target.id.is_some() {
+                Action::ToggleEngage
+            } else {
+                Action::OpenMenu
+            };
+            if let Some(key) = bound_key(&bindings, action) {
+                keys.press(key);
+                keys.release(key);
+            }
+        } else if let Some(key) = bound_key(&bindings, Action::NavConfirm) {
+            synth_nav_key(&mut keyboard_writer, window, key);
+        }
+    }
+
+    if gamepad.just_pressed(GamepadButton::East) && !matches!(*mode, InputMode::World) {
+        if let Some(key) = bound_key(&bindings, Action::NavCancel) {
+            synth_nav_key(&mut keyboard_writer, window, key);
         }
     }
 }

--- a/ffxi-client/src/view_native/gamepad_input.rs
+++ b/ffxi-client/src/view_native/gamepad_input.rs
@@ -236,8 +236,10 @@ fn synth_bound_key(
 /// - West: `ToggleEngage` — combat engage/disengage gets its own button now
 ///   that South is the general-purpose interact button.
 /// - North: `OpenMenu`.
-/// - D-pad right: `CycleTarget` — without this there was no gamepad-only way
-///   to select an NPC or player to interact with at all.
+/// - D-pad: `CycleTarget` (right, `World` mode) for selecting an NPC/player to
+///   interact with; `NavUp`/`NavDown`/`NavLeft`/`NavRight` otherwise, for
+///   moving the selection within an open menu (e.g. into the Magic/Abilities/
+///   Items submenus).
 /// - Right trigger: `OpenChat`.
 ///
 /// Only the first connected `Gamepad` entity is read — see the doc comment
@@ -287,8 +289,24 @@ pub(super) fn gamepad_ingame_action_system(
         pulse_bound_key(&mut keys, &bindings, Action::OpenMenu);
     }
 
-    if in_world && gamepad.just_pressed(GamepadButton::DPadRight) {
-        pulse_bound_key(&mut keys, &bindings, Action::CycleTarget);
+    if gamepad.just_pressed(GamepadButton::DPadRight) {
+        if in_world {
+            pulse_bound_key(&mut keys, &bindings, Action::CycleTarget);
+        } else {
+            synth_bound_key(&mut keyboard_writer, window, &bindings, Action::NavRight);
+        }
+    }
+
+    if !in_world {
+        if gamepad.just_pressed(GamepadButton::DPadUp) {
+            synth_bound_key(&mut keyboard_writer, window, &bindings, Action::NavUp);
+        }
+        if gamepad.just_pressed(GamepadButton::DPadDown) {
+            synth_bound_key(&mut keyboard_writer, window, &bindings, Action::NavDown);
+        }
+        if gamepad.just_pressed(GamepadButton::DPadLeft) {
+            synth_bound_key(&mut keyboard_writer, window, &bindings, Action::NavLeft);
+        }
     }
 
     if in_world && gamepad.just_pressed(GamepadButton::RightTrigger2) {

--- a/ffxi-client/src/view_native/gamepad_input.rs
+++ b/ffxi-client/src/view_native/gamepad_input.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use bevy::input::gamepad::{Gamepad, GamepadButton};
+use bevy::input::gamepad::{Gamepad, GamepadButton, GamepadConnectionEvent};
 use bevy::input::keyboard::{Key, KeyboardInput};
 use bevy::input::{ButtonInput, ButtonState};
 use bevy::input_focus::tab_navigation::{NavAction, TabNavigation, TabNavigationError};
@@ -11,6 +11,40 @@ use bevy::window::PrimaryWindow;
 use ffxi_viewer_core::{Action, Bindings, InputMode};
 
 const STICK_DEADZONE: f32 = 0.35;
+
+/// Pins gamepad-reading systems to one physical device, rather than each
+/// calling `gamepads.iter().next()` independently. Steam Input can mirror one
+/// physical Deck controller as two simultaneous `Gamepad` entities (see the
+/// doc comment on `gamepad_launcher_nav_system`); if the launcher's and the
+/// in-game systems each pick a different one of the pair, a mirrored press
+/// can still read as `just_pressed` on the *other* entity on the very first
+/// in-game frame after a screen transition (e.g. login's character-select
+/// confirm bleeding into an in-game target-action confirm). Latching to the
+/// first-ever-connected entity and holding it across screens closes that gap.
+#[derive(Resource, Default)]
+pub(super) struct PrimaryGamepad(Option<Entity>);
+
+pub(super) fn track_primary_gamepad_system(
+    mut primary: ResMut<PrimaryGamepad>,
+    mut connections: MessageReader<GamepadConnectionEvent>,
+) {
+    for ev in connections.read() {
+        if ev.connected() {
+            if primary.0.is_none() {
+                primary.0 = Some(ev.gamepad);
+            }
+        } else if primary.0 == Some(ev.gamepad) {
+            primary.0 = None;
+        }
+    }
+}
+
+fn primary_gamepad<'a>(
+    primary: &PrimaryGamepad,
+    gamepads: &'a Query<&Gamepad>,
+) -> Option<&'a Gamepad> {
+    primary.0.and_then(|e| gamepads.get(e).ok())
+}
 
 #[derive(Resource, Default)]
 pub(super) struct GamepadAxisHeld {
@@ -45,12 +79,17 @@ fn bound_key(bindings: &Bindings, action: Action) -> Option<KeyCode> {
 /// `bevy_input_focus`/`bevy_ui_widgets` machinery every launcher_ui screen
 /// already uses for keyboard/mouse, so no per-screen changes are needed.
 ///
-/// Only the first connected `Gamepad` entity is read: Steam Input can expose
-/// one physical controller as two simultaneous devices (e.g. the Deck's own
-/// pad plus a virtual Xbox-pad mirror it creates for compatibility), and
-/// processing every entity would fire each button press once per device.
+/// Reads the pinned `PrimaryGamepad` device rather than picking one via
+/// `.iter().next()`: Steam Input can expose one physical controller as two
+/// simultaneous devices (e.g. the Deck's own pad plus a virtual Xbox-pad
+/// mirror it creates for compatibility), and processing every entity would
+/// fire each button press once per device. Pinning also keeps this system
+/// and the in-game ones (`gamepad_ingame_action_system`,
+/// `gamepad_movement_camera_system`) agreeing on the same device across a
+/// screen transition — see `PrimaryGamepad`'s doc comment.
 pub(super) fn gamepad_launcher_nav_system(
     gamepads: Query<&Gamepad>,
+    primary: Res<PrimaryGamepad>,
     nav: TabNavigation,
     mut focus: ResMut<InputFocus>,
     mut visible: ResMut<InputFocusVisible>,
@@ -60,7 +99,7 @@ pub(super) fn gamepad_launcher_nav_system(
     let Ok(window) = windows.single() else {
         return;
     };
-    let Some(gamepad) = gamepads.iter().next() else {
+    let Some(gamepad) = primary_gamepad(&primary, &gamepads) else {
         return;
     };
 
@@ -108,11 +147,12 @@ pub(super) fn gamepad_launcher_nav_system(
 /// see it exactly as if the bound key were physically held.
 pub(super) fn gamepad_movement_camera_system(
     gamepads: Query<&Gamepad>,
+    primary: Res<PrimaryGamepad>,
     bindings: Res<Bindings>,
     mut keys: ResMut<ButtonInput<KeyCode>>,
     mut held: ResMut<GamepadAxisHeld>,
 ) {
-    let Some(gamepad) = gamepads.iter().next() else {
+    let Some(gamepad) = primary_gamepad(&primary, &gamepads) else {
         for key in held.held.drain() {
             keys.release(key);
         }
@@ -244,10 +284,12 @@ fn synth_bound_key(
 ///   Items submenus).
 /// - Right trigger: `OpenChat`.
 ///
-/// Only the first connected `Gamepad` entity is read — see the doc comment
-/// on `gamepad_launcher_nav_system` for why.
+/// Reads the same pinned device every other gamepad system does — see
+/// `PrimaryGamepad`'s doc comment for why a per-call `.iter().next()` isn't
+/// enough to avoid Steam Input's dual-device mirroring.
 pub(super) fn gamepad_ingame_action_system(
     gamepads: Query<&Gamepad>,
+    primary: Res<PrimaryGamepad>,
     bindings: Res<Bindings>,
     mode: Res<InputMode>,
     trade_state: Res<ffxi_viewer_core::hud::trade::TradeState>,
@@ -258,7 +300,7 @@ pub(super) fn gamepad_ingame_action_system(
     let Ok(window) = windows.single() else {
         return;
     };
-    let Some(gamepad) = gamepads.iter().next() else {
+    let Some(gamepad) = primary_gamepad(&primary, &gamepads) else {
         return;
     };
     // A trade window doesn't change InputMode (text_input.rs checks

--- a/ffxi-client/src/view_native/gamepad_input.rs
+++ b/ffxi-client/src/view_native/gamepad_input.rs
@@ -8,7 +8,7 @@ use bevy::input_focus::{InputFocus, InputFocusVisible};
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 
-use ffxi_viewer_core::{Action, Bindings};
+use ffxi_viewer_core::{Action, Bindings, InputMode, Target};
 
 const STICK_DEADZONE: f32 = 0.35;
 
@@ -156,5 +156,64 @@ pub(super) fn gamepad_movement_camera_system(
             key,
             gamepad.pressed(GamepadButton::RightTrigger),
         );
+    }
+}
+
+fn synth_nav_key(writer: &mut MessageWriter<KeyboardInput>, window: Entity, key_code: KeyCode) {
+    let logical_key = match key_code {
+        KeyCode::Escape => Key::Escape,
+        _ => Key::Enter,
+    };
+    writer.write(KeyboardInput {
+        key_code,
+        logical_key,
+        state: ButtonState::Pressed,
+        text: None,
+        repeat: false,
+        window,
+    });
+}
+
+/// South is a single context-sensitive action button: whenever `InputMode`
+/// isn't `World` (a menu, dialog, or other overlay is open) it mirrors
+/// `NavConfirm` (Enter), exactly like `gamepad_launcher_nav_system` does for
+/// the launcher. In `World` mode it mirrors `ToggleEngage` if a target is
+/// selected, otherwise `OpenMenu` — matching `handle_input_system`'s own
+/// `InputMode::World` gating, so the two can never both fire off one press
+/// the way a raw keyboard-emulated `F` from Steam Input's Desktop profile
+/// could. East mirrors `NavCancel` (Escape) so a menu opened this way can
+/// also be closed with the gamepad.
+pub(super) fn gamepad_ingame_action_system(
+    gamepads: Query<&Gamepad>,
+    bindings: Res<Bindings>,
+    mode: Res<InputMode>,
+    target: Res<Target>,
+    mut keys: ResMut<ButtonInput<KeyCode>>,
+    mut keyboard_writer: MessageWriter<KeyboardInput>,
+    windows: Query<Entity, With<PrimaryWindow>>,
+) {
+    let Ok(window) = windows.single() else {
+        return;
+    };
+    for gamepad in &gamepads {
+        if gamepad.just_pressed(GamepadButton::South) {
+            if matches!(*mode, InputMode::World) {
+                let action = if target.id.is_some() {
+                    Action::ToggleEngage
+                } else {
+                    Action::OpenMenu
+                };
+                if let Some(key) = bound_key(&bindings, action) {
+                    keys.press(key);
+                    keys.release(key);
+                }
+            } else {
+                synth_nav_key(&mut keyboard_writer, window, KeyCode::Enter);
+            }
+        }
+
+        if gamepad.just_pressed(GamepadButton::East) && !matches!(*mode, InputMode::World) {
+            synth_nav_key(&mut keyboard_writer, window, KeyCode::Escape);
+        }
     }
 }

--- a/ffxi-client/src/view_native/gamepad_input.rs
+++ b/ffxi-client/src/view_native/gamepad_input.rs
@@ -8,8 +8,7 @@ use bevy::input_focus::{InputFocus, InputFocusVisible};
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 
-use ffxi_viewer_core::hud::death_prompt::is_dead;
-use ffxi_viewer_core::{Action, Bindings, InputMode, SceneState, Target};
+use ffxi_viewer_core::{Action, Bindings, InputMode};
 
 const STICK_DEADZONE: f32 = 0.35;
 
@@ -198,17 +197,48 @@ fn synth_nav_key(writer: &mut MessageWriter<KeyboardInput>, window: Entity, key_
     });
 }
 
-/// South is a single context-sensitive action button. While the death prompt
-/// is up it mirrors `ConfirmAction` (the /return-home dispatch text_input.rs
-/// intercepts before generic World-mode handling); otherwise, whenever
-/// `InputMode` isn't `World` (a menu, dialog, or other overlay is open) it
-/// mirrors `NavConfirm`, exactly like `gamepad_launcher_nav_system` does for
-/// the launcher. In plain `World` mode it mirrors `ToggleEngage` if a target
-/// is selected, otherwise `OpenMenu` — matching `handle_input_system`'s own
-/// `InputMode::World` gating, so the two can never both fire off one press
-/// the way a raw keyboard-emulated `F` from Steam Input's Desktop profile
-/// could. East mirrors `NavCancel` so a menu opened this way can also be
-/// closed with the gamepad.
+/// Pulses (press then release within the same frame) whatever `KeyCode` is
+/// bound to `action`, so a `ButtonInput::just_pressed` reader (`bound_key`'s
+/// other caller, `gamepad_movement_camera_system`, holds instead) sees a
+/// one-frame press exactly like a physical key tap.
+fn pulse_bound_key(keys: &mut ButtonInput<KeyCode>, bindings: &Bindings, action: Action) {
+    if let Some(key) = bound_key(bindings, action) {
+        keys.press(key);
+        keys.release(key);
+    }
+}
+
+/// Synthesizes a `KeyboardInput` press for whatever `KeyCode` is bound to
+/// `action`, for actions `text_input.rs` reads as raw key events rather than
+/// `ButtonInput` state (`ConfirmAction`, `OpenChat`, `NavConfirm`,
+/// `NavCancel` — all restricted to `logical_key_for`'s fixed key set).
+fn synth_bound_key(
+    writer: &mut MessageWriter<KeyboardInput>,
+    window: Entity,
+    bindings: &Bindings,
+    action: Action,
+) {
+    if let Some(key) = bound_key(bindings, action) {
+        synth_nav_key(writer, window, key);
+    }
+}
+
+/// Face buttons + D-pad-right; combat/targeting ones are gated to
+/// `InputMode::World`, mirroring `handle_input_system`'s own gate.
+///
+/// - South: `ConfirmAction` in `World` mode — FFXI's actual "talk to this NPC
+///   / open the trade-check-invite menu for this target" dispatch (also the
+///   /return-home dispatch while the death prompt is up, both handled by
+///   `text_input.rs`'s own `InputMode::World` branch), not `ToggleEngage`.
+///   Outside `World` mode (a menu/dialog is open), `NavConfirm`.
+/// - East: `ClearTarget` in `World` mode, `NavCancel` otherwise — so a menu
+///   opened via South can also be closed with the gamepad.
+/// - West: `ToggleEngage` — combat engage/disengage gets its own button now
+///   that South is the general-purpose interact button.
+/// - North: `OpenMenu`.
+/// - D-pad right: `CycleTarget` — without this there was no gamepad-only way
+///   to select an NPC or player to interact with at all.
+/// - Right trigger: `OpenChat`.
 ///
 /// Only the first connected `Gamepad` entity is read — see the doc comment
 /// on `gamepad_launcher_nav_system` for why.
@@ -216,8 +246,6 @@ pub(super) fn gamepad_ingame_action_system(
     gamepads: Query<&Gamepad>,
     bindings: Res<Bindings>,
     mode: Res<InputMode>,
-    target: Res<Target>,
-    scene_state: Res<SceneState>,
     mut keys: ResMut<ButtonInput<KeyCode>>,
     mut keyboard_writer: MessageWriter<KeyboardInput>,
     windows: Query<Entity, With<PrimaryWindow>>,
@@ -228,30 +256,42 @@ pub(super) fn gamepad_ingame_action_system(
     let Some(gamepad) = gamepads.iter().next() else {
         return;
     };
+    let in_world = matches!(*mode, InputMode::World);
 
     if gamepad.just_pressed(GamepadButton::South) {
-        if matches!(*mode, InputMode::World) && is_dead(&scene_state) {
-            if let Some(key) = bound_key(&bindings, Action::ConfirmAction) {
-                synth_nav_key(&mut keyboard_writer, window, key);
-            }
-        } else if matches!(*mode, InputMode::World) {
-            let action = if target.id.is_some() {
-                Action::ToggleEngage
-            } else {
-                Action::OpenMenu
-            };
-            if let Some(key) = bound_key(&bindings, action) {
-                keys.press(key);
-                keys.release(key);
-            }
-        } else if let Some(key) = bound_key(&bindings, Action::NavConfirm) {
-            synth_nav_key(&mut keyboard_writer, window, key);
+        if in_world {
+            synth_bound_key(
+                &mut keyboard_writer,
+                window,
+                &bindings,
+                Action::ConfirmAction,
+            );
+        } else {
+            synth_bound_key(&mut keyboard_writer, window, &bindings, Action::NavConfirm);
         }
     }
 
-    if gamepad.just_pressed(GamepadButton::East) && !matches!(*mode, InputMode::World) {
-        if let Some(key) = bound_key(&bindings, Action::NavCancel) {
-            synth_nav_key(&mut keyboard_writer, window, key);
+    if gamepad.just_pressed(GamepadButton::East) {
+        if in_world {
+            pulse_bound_key(&mut keys, &bindings, Action::ClearTarget);
+        } else {
+            synth_bound_key(&mut keyboard_writer, window, &bindings, Action::NavCancel);
         }
+    }
+
+    if in_world && gamepad.just_pressed(GamepadButton::West) {
+        pulse_bound_key(&mut keys, &bindings, Action::ToggleEngage);
+    }
+
+    if in_world && gamepad.just_pressed(GamepadButton::North) {
+        pulse_bound_key(&mut keys, &bindings, Action::OpenMenu);
+    }
+
+    if in_world && gamepad.just_pressed(GamepadButton::DPadRight) {
+        pulse_bound_key(&mut keys, &bindings, Action::CycleTarget);
+    }
+
+    if in_world && gamepad.just_pressed(GamepadButton::RightTrigger2) {
+        synth_bound_key(&mut keyboard_writer, window, &bindings, Action::OpenChat);
     }
 }

--- a/ffxi-client/src/view_native/input.rs
+++ b/ffxi-client/src/view_native/input.rs
@@ -64,6 +64,22 @@ pub struct HeadingTurnAccum {
     pub units: f32,
 }
 
+/// `InputMode`/`Target`/`LockOn` are process-lifetime resources, not
+/// per-session state — without this, logging back into the world (reconnect,
+/// crash recovery) resumes whatever mode was active when the previous
+/// session ended (e.g. `InputMode::TargetAction`, showing the action menu
+/// open with no input at all), since `reset_interaction_flags_on_zone_change`
+/// only fires on an in-session zone change, not a fresh world entry.
+pub fn reset_interaction_state_on_enter_world(
+    mut mode: ResMut<InputMode>,
+    mut lock_on: ResMut<LockOn>,
+    mut target: ResMut<Target>,
+) {
+    *mode = InputMode::World;
+    lock_on.target_id = None;
+    target.id = None;
+}
+
 pub fn reset_interaction_flags_on_zone_change(
     state: Res<SceneState>,
     mut prev_zone: Local<Option<Option<u16>>>,

--- a/ffxi-client/src/view_native/input.rs
+++ b/ffxi-client/src/view_native/input.rs
@@ -199,7 +199,7 @@ pub fn handle_input_system(
                 .map(|e| e.id)
                 .collect();
 
-            if let Some(next) = tab_cycle_next(
+            let next = tab_cycle_next(
                 &mut tab_stack,
                 &state.snapshot.entities,
                 state.snapshot.self_pos.pos,
@@ -208,9 +208,23 @@ pub fn handle_input_system(
                 &party_ids,
                 &owned_pet_ids,
                 |world_pos| camera.world_to_ndc(&cam_global, world_pos),
-            ) {
+            );
+            tracing::info!(
+                tab,
+                enter_acquire,
+                entity_count = state.snapshot.entities.len(),
+                acquired = ?next,
+                "cycle-target dispatch"
+            );
+            if let Some(next) = next {
                 target.id = Some(next);
             }
+        } else {
+            tracing::info!(
+                tab,
+                enter_acquire,
+                "cycle-target dispatch: no camera entity"
+            );
         }
     }
 
@@ -262,20 +276,31 @@ pub fn handle_input_system(
                 local_seq: 0,
             });
         } else {
-            match target.id {
-                Some(id) => {
-                    let name = state
-                        .snapshot
-                        .entities
-                        .iter()
-                        .find(|e| e.id == id)
-                        .and_then(|e| e.name.clone())
-                        .unwrap_or_else(|| format!("#{id:08X}"));
+            match target.id.and_then(|id| {
+                state
+                    .snapshot
+                    .entities
+                    .iter()
+                    .find(|e| e.id == id)
+                    .map(|e| (id, e))
+            }) {
+                Some((id, entity)) if matches!(entity.kind, EntityKind::Mob) => {
+                    let name = entity.name.clone().unwrap_or_else(|| format!("#{id:08X}"));
                     let _ = cmd_tx.0.try_send(AgentCommand::Engage { target_id: id });
                     state.push_local_toast(ffxi_viewer_wire::ChatLine {
                         channel: ffxi_viewer_wire::ChatChannel::Debug,
                         sender: "client".into(),
                         text: format!("engaging {name}"),
+                        server_ts: 0,
+                        local_seq: 0,
+                    });
+                }
+                Some((_, entity)) => {
+                    let name = entity.name.clone().unwrap_or_else(|| "target".into());
+                    state.push_local_toast(ffxi_viewer_wire::ChatLine {
+                        channel: ffxi_viewer_wire::ChatChannel::Debug,
+                        sender: "client".into(),
+                        text: format!("cannot engage: {name} is not attackable"),
                         server_ts: 0,
                         local_seq: 0,
                     });

--- a/ffxi-client/src/view_native/launcher_backdrop.rs
+++ b/ffxi-client/src/view_native/launcher_backdrop.rs
@@ -149,7 +149,10 @@ fn spawn_backdrop_camera(
 
 fn despawn_backdrop_camera(mut commands: Commands, q: Query<Entity, With<BackdropScoped>>) {
     for e in q.iter() {
-        commands.entity(e).despawn();
+        // try_despawn: this OnExit(Launcher) sweep can race the launcher's
+        // own Update-schedule backdrop-swap/preview teardown in the final
+        // frame before entering the game — an expected race, not a bug.
+        commands.entity(e).try_despawn();
     }
 
     commands.remove_resource::<BackdropFadeMaterial>();

--- a/ffxi-client/src/view_native/launcher_ui/async_work.rs
+++ b/ffxi-client/src/view_native/launcher_ui/async_work.rs
@@ -5,6 +5,7 @@ use bevy::prelude::*;
 use ffxi_client::auth_client::AuthClient;
 use ffxi_client::lobby_client::{LobbyClient, LobbyHandle, MapHandoff};
 use ffxi_client::session::InitialState;
+use rand::Rng;
 use tokio::runtime::Handle as RtHandle;
 use tokio::sync::oneshot;
 
@@ -289,10 +290,13 @@ async fn select_with_existing_handle(
     slot: &ffxi_client::lobby_client::CharSlot,
     auth_session: ffxi_client::auth_client::AuthSession,
 ) -> std::result::Result<ConnectOk, ConnectErr> {
+    // Must be fresh per login attempt: LSB stores this verbatim as
+    // accounts_sessions.session_key (src/login/data_session.cpp) and the map
+    // server keys its session/blowfish lookup off it — a repeated key3 can
+    // collide with a stale row from an earlier attempt that was never
+    // cleaned up, silently breaking the new connection.
     let mut key3 = [0u8; 20];
-    for (i, b) in key3.iter_mut().enumerate() {
-        *b = ((i as u8).wrapping_mul(0x37)) ^ 0x5a;
-    }
+    rand::rng().fill(&mut key3);
     let handoff = handle
         .select(slot.char_id, &slot.name, key3)
         .await
@@ -322,10 +326,13 @@ async fn reopen_and_select(
         msg: format!("reopening lobby: {e}"),
         return_to: LoginErrorReturn::CharList,
     })?;
+    // Must be fresh per login attempt: LSB stores this verbatim as
+    // accounts_sessions.session_key (src/login/data_session.cpp) and the map
+    // server keys its session/blowfish lookup off it — a repeated key3 can
+    // collide with a stale row from an earlier attempt that was never
+    // cleaned up, silently breaking the new connection.
     let mut key3 = [0u8; 20];
-    for (i, b) in key3.iter_mut().enumerate() {
-        *b = ((i as u8).wrapping_mul(0x37)) ^ 0x5a;
-    }
+    rand::rng().fill(&mut key3);
     let handoff = handle
         .select(slot.char_id, &slot.name, key3)
         .await

--- a/ffxi-client/src/view_native/launcher_ui/async_work.rs
+++ b/ffxi-client/src/view_native/launcher_ui/async_work.rs
@@ -5,6 +5,7 @@ use bevy::prelude::*;
 use ffxi_client::auth_client::AuthClient;
 use ffxi_client::lobby_client::{LobbyClient, LobbyHandle, MapHandoff};
 use ffxi_client::session::InitialState;
+use tokio::runtime::Handle as RtHandle;
 use tokio::sync::oneshot;
 
 use crate::launcher::Selection;
@@ -19,7 +20,13 @@ use super::{
 use ffxi_client::launcher_store::{self, keyring_account_key, SavedAccount, KEYRING_SERVICE};
 use ffxi_client::secret_store::SecretStore;
 
-fn save_on_success(server_name: &str, username: &str, password: &str, remember: bool) {
+fn save_on_success(
+    runtime: &RtHandle,
+    server_name: &str,
+    username: &str,
+    password: &str,
+    remember: bool,
+) {
     let mut store = launcher_store::load();
 
     store
@@ -39,9 +46,9 @@ fn save_on_success(server_name: &str, username: &str, password: &str, remember: 
     }
     let key = keyring_account_key(server_name, username);
     if remember {
-        SecretStore::set(KEYRING_SERVICE, &key, password);
+        SecretStore::set(runtime, KEYRING_SERVICE, &key, password);
     } else {
-        SecretStore::delete(KEYRING_SERVICE, &key);
+        SecretStore::delete(runtime, KEYRING_SERVICE, &key);
     }
 }
 
@@ -124,6 +131,7 @@ pub(super) fn poll_auth_system(
     form: Res<LoginForm>,
     server_form: Res<ServerSelectForm>,
     server_info: Res<super::ServerInfo>,
+    runtime: Res<RuntimeHandle>,
 ) {
     match chan.rx.try_recv() {
         Ok(Ok(ok)) => {
@@ -141,7 +149,13 @@ pub(super) fn poll_auth_system(
                 .selected
                 .clone()
                 .unwrap_or_else(|| server_info.server.clone());
-            save_on_success(&server_name, &ok.user, &ok.pass, form.remember_password);
+            save_on_success(
+                &runtime.0,
+                &server_name,
+                &ok.user,
+                &ok.pass,
+                form.remember_password,
+            );
             creds.user = ok.user;
             creds.pass = ok.pass;
             commands.remove_resource::<AuthInFlightChan>();

--- a/ffxi-client/src/view_native/launcher_ui/char_preview.rs
+++ b/ffxi-client/src/view_native/launcher_ui/char_preview.rs
@@ -205,7 +205,7 @@ pub(super) fn refresh_preview_on_cursor_change(
             let char_id = slot.char_id;
 
             let task = AsyncComputeTaskPool::get()
-                .spawn(async move { load_pc(race, &equipment, None, None) });
+                .spawn(async move { load_pc(char_id, race, &equipment, None, None) });
             pending.task = Some((char_id, task));
         }
         _ => pending.task = None,

--- a/ffxi-client/src/view_native/launcher_ui/login.rs
+++ b/ffxi-client/src/view_native/launcher_ui/login.rs
@@ -3,6 +3,7 @@ use bevy::feathers::controls::{button, checkbox, ButtonProps, ButtonVariant};
 use bevy::feathers::theme::ThemedText;
 use bevy::input::keyboard::{Key, KeyboardInput};
 use bevy::input::ButtonState;
+use bevy::input_focus::{InputFocus, InputFocusVisible};
 use bevy::prelude::*;
 use bevy::ui::Checked;
 use bevy::ui_widgets::{Activate, ValueChange};
@@ -15,8 +16,8 @@ use super::common::{
 };
 use super::server_version_check::{ServerVersionStatus, VersionViolation};
 use super::{
-    Credentials, LauncherState, LoginErrorMsg, LoginErrorReturn, LoginField, LoginForm,
-    RuntimeHandle, ServerInfo, ServerSelectForm,
+    Credentials, LauncherState, LoginErrorMsg, LoginErrorReturn, LoginField, LoginFocusPending,
+    LoginForm, RuntimeHandle, ServerInfo, ServerSelectForm,
 };
 use crate::view_native::widgets::text_field::{text_field, TextFieldSubmitted};
 use crate::view_native::widgets::{TextFieldDisplay, TextFieldProps};
@@ -44,8 +45,13 @@ pub(super) fn spawn_login_ui(
     form: Res<LoginForm>,
     server_form: Res<ServerSelectForm>,
     version: Res<ServerVersionStatus>,
+    mut pending: ResMut<LoginFocusPending>,
 ) {
     build_login_ui(&mut commands, &server, &form, &server_form, &version);
+    // Every entry into the Login screen (fresh launch, cancel-back from
+    // ServerSelect, etc.) should land InputFocus on form.focus rather than
+    // stranding it on whatever was focused on the previous screen.
+    pending.0 = true;
 }
 
 pub(super) fn rebuild_login_ui_system(
@@ -65,6 +71,31 @@ pub(super) fn rebuild_login_ui_system(
         commands.entity(e).despawn();
     }
     build_login_ui(&mut commands, &server, &form, &server_form, &version);
+}
+
+/// Restores `InputFocus` to the field `LoginForm::focus` points at after a
+/// saved-account pick (or the `mod.rs` server-select preselect path) rebuilds
+/// the login screen — the rebuilt `LoginField`-tagged text fields are new
+/// entities, so without this a gamepad/keyboard user loses focus back to the
+/// tab order's start. If both fields end up filled, focusing the password
+/// field is enough on its own: it's `submit_on_enter`, so one more
+/// confirm press logs in (see the `TextFieldSubmitted` observer below).
+pub(super) fn apply_login_focus_system(
+    mut pending: ResMut<LoginFocusPending>,
+    form: Res<LoginForm>,
+    fields: Query<(Entity, &LoginField)>,
+    mut focus: ResMut<InputFocus>,
+    mut visible: ResMut<InputFocusVisible>,
+) {
+    if !pending.0 {
+        return;
+    }
+    pending.0 = false;
+
+    if let Some((entity, _)) = fields.iter().find(|(_, f)| **f == form.focus) {
+        focus.set(entity);
+        visible.0 = true;
+    }
 }
 
 pub(super) fn mark_dirty_on_version_change(
@@ -234,6 +265,7 @@ fn spawn_saved_accounts_row(
                 move |_ev: On<Activate>,
                       mut login: ResMut<LoginForm>,
                       mut dirty: ResMut<LoginUiDirty>,
+                      mut pending: ResMut<LoginFocusPending>,
                       runtime: Res<RuntimeHandle>| {
                     login.user = pick_user.clone();
                     login.pass.clear();
@@ -254,6 +286,7 @@ fn spawn_saved_accounts_row(
                     };
 
                     dirty.0 = true;
+                    pending.0 = true;
                 },
             );
 
@@ -268,6 +301,7 @@ fn spawn_saved_accounts_row(
                 move |_ev: On<Activate>,
                       mut login: ResMut<LoginForm>,
                       mut dirty: ResMut<LoginUiDirty>,
+                      mut pending: ResMut<LoginFocusPending>,
                       runtime: Res<RuntimeHandle>| {
                     let mut store = launcher_store::load();
                     store
@@ -294,6 +328,7 @@ fn spawn_saved_accounts_row(
                         login.focus = LoginField::User;
                     }
                     dirty.0 = true;
+                    pending.0 = true;
                 },
             );
         }
@@ -304,12 +339,16 @@ fn spawn_saved_accounts_row(
             Spawn((Text::new("+ New"), ThemedText)),
         ))
         .observe(
-            |_ev: On<Activate>, mut login: ResMut<LoginForm>, mut dirty: ResMut<LoginUiDirty>| {
+            |_ev: On<Activate>,
+             mut login: ResMut<LoginForm>,
+             mut dirty: ResMut<LoginUiDirty>,
+             mut pending: ResMut<LoginFocusPending>| {
                 login.user.clear();
                 login.pass.clear();
                 login.remember_password = false;
                 login.focus = LoginField::User;
                 dirty.0 = true;
+                pending.0 = true;
             },
         );
     });
@@ -393,12 +432,15 @@ fn spawn_field(
                 Text::new(label.to_string()),
                 ThemedText,
             ));
-            row.spawn(text_field(TextFieldProps {
-                initial: initial.to_string(),
-                mask,
-                submit_on_enter: true,
-                ..default()
-            }))
+            row.spawn((
+                text_field(TextFieldProps {
+                    initial: initial.to_string(),
+                    mask,
+                    submit_on_enter: true,
+                    ..default()
+                }),
+                binding,
+            ))
             .with_children(|tf| {
                 tf.spawn((
                     Node {

--- a/ffxi-client/src/view_native/launcher_ui/login.rs
+++ b/ffxi-client/src/view_native/launcher_ui/login.rs
@@ -15,8 +15,8 @@ use super::common::{
 };
 use super::server_version_check::{ServerVersionStatus, VersionViolation};
 use super::{
-    Credentials, LauncherState, LoginErrorMsg, LoginErrorReturn, LoginField, LoginForm, ServerInfo,
-    ServerSelectForm,
+    Credentials, LauncherState, LoginErrorMsg, LoginErrorReturn, LoginField, LoginForm,
+    RuntimeHandle, ServerInfo, ServerSelectForm,
 };
 use crate::view_native::widgets::text_field::{text_field, TextFieldSubmitted};
 use crate::view_native::widgets::{TextFieldDisplay, TextFieldProps};
@@ -233,12 +233,14 @@ fn spawn_saved_accounts_row(
             .observe(
                 move |_ev: On<Activate>,
                       mut login: ResMut<LoginForm>,
-                      mut dirty: ResMut<LoginUiDirty>| {
+                      mut dirty: ResMut<LoginUiDirty>,
+                      runtime: Res<RuntimeHandle>| {
                     login.user = pick_user.clone();
                     login.pass.clear();
                     login.remember_password = pick_remember;
                     if pick_remember {
                         if let Some(pw) = SecretStore::get(
+                            &runtime.0,
                             KEYRING_SERVICE,
                             &keyring_account_key(&pick_server, &pick_user),
                         ) {
@@ -265,7 +267,8 @@ fn spawn_saved_accounts_row(
             .observe(
                 move |_ev: On<Activate>,
                       mut login: ResMut<LoginForm>,
-                      mut dirty: ResMut<LoginUiDirty>| {
+                      mut dirty: ResMut<LoginUiDirty>,
+                      runtime: Res<RuntimeHandle>| {
                     let mut store = launcher_store::load();
                     store
                         .accounts
@@ -279,6 +282,7 @@ fn spawn_saved_accounts_row(
                         tracing::warn!(error = %e, "launcher_store: save failed");
                     }
                     SecretStore::delete(
+                        &runtime.0,
                         KEYRING_SERVICE,
                         &keyring_account_key(&forget_server, &forget_user),
                     );

--- a/ffxi-client/src/view_native/launcher_ui/mod.rs
+++ b/ffxi-client/src/view_native/launcher_ui/mod.rs
@@ -965,6 +965,7 @@ fn decide_initial_screen(
     mut server_form: ResMut<ServerSelectForm>,
     mut server_info: ResMut<ServerInfo>,
     mut next: ResMut<NextState<LauncherState>>,
+    runtime: Res<RuntimeHandle>,
 ) {
     if !err.0.is_empty() {
         return;
@@ -997,6 +998,7 @@ fn decide_initial_screen(
         form.remember_password = prefill.account.remember_password;
         if prefill.account.remember_password {
             if let Some(pw) = ffxi_client::secret_store::SecretStore::get(
+                &runtime.0,
                 ffxi_client::launcher_store::KEYRING_SERVICE,
                 &ffxi_client::launcher_store::keyring_account_key(
                     &prefill.account.server_name,

--- a/ffxi-client/src/view_native/launcher_ui/mod.rs
+++ b/ffxi-client/src/view_native/launcher_ui/mod.rs
@@ -245,12 +245,21 @@ fn cycle_table(table: &[(u8, &str)], current: u8, delta: i32) -> u8 {
 #[derive(Resource, Default)]
 pub(crate) struct CharCreateError(pub String);
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Component)]
 pub(crate) enum LoginField {
     #[default]
     User,
     Password,
 }
+
+/// Set alongside `LoginForm::focus` whenever a saved-account pick (or
+/// forgetting one) rebuilds the login screen out from under the player's
+/// current `InputFocus` — the rebuilt widgets are new entities, so without
+/// this a gamepad/keyboard user would land back at the top of the tab order
+/// instead of on the field `LoginForm::focus` already says they should be on.
+/// Consumed by `login::apply_login_focus_system`.
+#[derive(Resource, Default)]
+pub(crate) struct LoginFocusPending(pub bool);
 
 #[derive(Resource, Default)]
 pub(crate) struct LoginForm {
@@ -561,6 +570,7 @@ pub(crate) fn register(
     app.add_sub_state::<LauncherState>()
         .insert_resource(form)
         .insert_resource(login::LoginUiDirty::default())
+        .insert_resource(LoginFocusPending::default())
         .insert_resource(LoginErrorMsg::default())
         .insert_resource(LoginErrorReturn::default())
         .insert_resource(RuntimeHandle(runtime))
@@ -705,19 +715,26 @@ pub(crate) fn register(
             .run_if(in_state(LauncherState::ChangePasswordInFlight)),
     );
 
-    app.add_systems(OnEnter(LauncherState::Login), login::spawn_login_ui)
-        .add_systems(OnExit(LauncherState::Login), login::despawn_login_ui)
-        .add_systems(
-            Update,
+    app.add_systems(
+        OnEnter(LauncherState::Login),
+        (login::spawn_login_ui, login::apply_login_focus_system).chain(),
+    )
+    .add_systems(OnExit(LauncherState::Login), login::despawn_login_ui)
+    .add_systems(
+        Update,
+        (
+            direct_mode_login_autostart,
+            login::keyboard_input_system,
+            login::redraw_login_form_system,
+            login::mark_dirty_on_version_change.before(login::rebuild_login_ui_system),
             (
-                direct_mode_login_autostart,
-                login::keyboard_input_system,
-                login::redraw_login_form_system,
-                login::mark_dirty_on_version_change.before(login::rebuild_login_ui_system),
                 login::rebuild_login_ui_system,
+                login::apply_login_focus_system,
             )
-                .run_if(in_state(LauncherState::Login)),
-        );
+                .chain(),
+        )
+            .run_if(in_state(LauncherState::Login)),
+    );
 
     app.add_systems(
         OnEnter(LauncherState::AuthInFlight),

--- a/ffxi-client/src/view_native/launcher_ui/server_select.rs
+++ b/ffxi-client/src/view_native/launcher_ui/server_select.rs
@@ -10,7 +10,7 @@ use ffxi_client::launcher_store::{self, keyring_account_key, KEYRING_SERVICE};
 use ffxi_client::secret_store::SecretStore;
 
 use super::common::{hint, panel_node, row, screen_root, spawn_close_titlebar};
-use super::{LauncherState, ServerSelectCursor, ServerSelectForm};
+use super::{LauncherState, RuntimeHandle, ServerSelectCursor, ServerSelectForm};
 
 #[derive(Component)]
 pub(super) struct ServerSelectRoot;
@@ -86,7 +86,8 @@ pub(super) fn spawn_ui(
                                       mut cursor: ResMut<ServerSelectCursor>,
                                       mut form: ResMut<ServerSelectForm>,
                                       mut login: ResMut<super::LoginForm>,
-                                      mut next: ResMut<NextState<LauncherState>>| {
+                                      mut next: ResMut<NextState<LauncherState>>,
+                                      runtime: Res<RuntimeHandle>| {
                                     cursor.0 = idx;
                                     form.selected = Some(pick_name.clone());
                                     let store = launcher_store::load();
@@ -96,18 +97,14 @@ pub(super) fn spawn_ui(
                                         super::apply_server_profile(&mut commands, profile);
                                     }
 
-                                    if let Some(acct) =
-                                        store.preselect_account_for(&pick_name)
-                                    {
+                                    if let Some(acct) = store.preselect_account_for(&pick_name) {
                                         login.user = acct.username.clone();
                                         login.remember_password = acct.remember_password;
                                         login.pass = if acct.remember_password {
                                             SecretStore::get(
+                                                &runtime.0,
                                                 KEYRING_SERVICE,
-                                                &keyring_account_key(
-                                                    &pick_name,
-                                                    &acct.username,
-                                                ),
+                                                &keyring_account_key(&pick_name, &acct.username),
                                             )
                                             .unwrap_or_default()
                                         } else {

--- a/ffxi-client/src/view_native/mod.rs
+++ b/ffxi-client/src/view_native/mod.rs
@@ -321,7 +321,12 @@ pub fn run(args: NativeRunArgs) -> Result<()> {
 
     app.add_systems(
         OnEnter(AppPhase::InGame),
-        (setup_world, spawn_camera, setup_zone_line_assets),
+        (
+            setup_world,
+            spawn_camera,
+            setup_zone_line_assets,
+            input::reset_interaction_state_on_enter_world,
+        ),
     );
     add_hud_spawners(&mut app, OnEnter(AppPhase::InGame));
     app.init_resource::<perf_hud::PerfMonitor>();

--- a/ffxi-client/src/view_native/mod.rs
+++ b/ffxi-client/src/view_native/mod.rs
@@ -580,7 +580,11 @@ fn despawn_ingame_entities(
 ) {
     let mut count = 0usize;
     for entity in q.iter() {
-        commands.entity(entity).despawn();
+        // try_despawn: the Update schedule's final InGame frame can still
+        // queue per-domain cleanup despawns (zone_clouds, dat_mzb,
+        // particle_sim, ...) for the same entities this bulk sweep also
+        // targets — an expected race with OnExit, not a bug.
+        commands.entity(entity).try_despawn();
         count += 1;
     }
 

--- a/ffxi-client/src/view_native/mod.rs
+++ b/ffxi-client/src/view_native/mod.rs
@@ -430,20 +430,19 @@ pub fn run(args: NativeRunArgs) -> Result<()> {
         gamepad_input::gamepad_launcher_nav_system.run_if(in_state(AppPhase::Launcher)),
     );
 
-    // PreUpdate so the held/released KeyCodes it synthesizes are already in
-    // place before this frame's FixedUpdate (dispatch_movement_system) and
-    // Update (handle_input_system) steps read `ButtonInput<KeyCode>`.
+    // bevy::input::keyboard::keyboard_input_system::clear() must run first.
     app.add_systems(
         PreUpdate,
-        gamepad_input::gamepad_movement_camera_system.run_if(in_state(AppPhase::InGame)),
+        gamepad_input::gamepad_movement_camera_system
+            .after(bevy::input::InputSystems)
+            .run_if(in_state(AppPhase::InGame)),
     );
 
-    // PreUpdate for the same reason: the pulsed ButtonInput press/release and
-    // the synthesized KeyboardInput both need to be visible before this
-    // frame's Update-schedule handle_input_system/text_input_system chain.
     app.add_systems(
         PreUpdate,
-        gamepad_input::gamepad_ingame_action_system.run_if(in_state(AppPhase::InGame)),
+        gamepad_input::gamepad_ingame_action_system
+            .after(bevy::input::InputSystems)
+            .run_if(in_state(AppPhase::InGame)),
     );
 
     app.add_systems(

--- a/ffxi-client/src/view_native/mod.rs
+++ b/ffxi-client/src/view_native/mod.rs
@@ -3,6 +3,7 @@ pub mod camera_collision;
 pub mod collision_bvh;
 pub mod debug_heights;
 pub mod exit_watchdog;
+mod gamepad_input;
 pub mod input;
 pub mod launcher_backdrop;
 pub mod launcher_ui;
@@ -211,6 +212,9 @@ pub fn run(args: NativeRunArgs) -> Result<()> {
             title: format!("ffxi-client — {server}"),
             resolution: (1280u32, 800u32).into(),
             mode: window_mode,
+            // Lets Wayland/gamescope show the Steam Deck's on-screen keyboard
+            // when a text field gains focus; off by default.
+            ime_enabled: true,
             ..default()
         }),
         ..default()
@@ -419,6 +423,20 @@ pub fn run(args: NativeRunArgs) -> Result<()> {
 
     app.init_resource::<input::TabCycleStack>();
     app.init_resource::<input::SelectTargetMode>();
+    app.init_resource::<gamepad_input::GamepadAxisHeld>();
+
+    app.add_systems(
+        Update,
+        gamepad_input::gamepad_launcher_nav_system.run_if(in_state(AppPhase::Launcher)),
+    );
+
+    // PreUpdate so the held/released KeyCodes it synthesizes are already in
+    // place before this frame's FixedUpdate (dispatch_movement_system) and
+    // Update (handle_input_system) steps read `ButtonInput<KeyCode>`.
+    app.add_systems(
+        PreUpdate,
+        gamepad_input::gamepad_movement_camera_system.run_if(in_state(AppPhase::InGame)),
+    );
 
     app.add_systems(
         Update,

--- a/ffxi-client/src/view_native/mod.rs
+++ b/ffxi-client/src/view_native/mod.rs
@@ -429,6 +429,12 @@ pub fn run(args: NativeRunArgs) -> Result<()> {
     app.init_resource::<input::TabCycleStack>();
     app.init_resource::<input::SelectTargetMode>();
     app.init_resource::<gamepad_input::GamepadAxisHeld>();
+    app.init_resource::<gamepad_input::PrimaryGamepad>();
+
+    app.add_systems(
+        PreUpdate,
+        gamepad_input::track_primary_gamepad_system.before(bevy::input::InputSystems),
+    );
 
     app.add_systems(
         Update,

--- a/ffxi-client/src/view_native/mod.rs
+++ b/ffxi-client/src/view_native/mod.rs
@@ -673,18 +673,26 @@ fn return_to_launcher_on_disconnect(
         return;
     }
 
-    let kind = events
-        .as_ref()
-        .and_then(|log| {
-            log.recent.iter().rev().find_map(|e| match e {
-                ViewerEvent::Disconnected { reason } => Some(classify_disconnect_reason(reason)),
-                _ => None,
-            })
+    let found = events.as_ref().and_then(|log| {
+        log.recent.iter().rev().find_map(|e| match e {
+            ViewerEvent::Disconnected { reason } => {
+                Some((classify_disconnect_reason(reason), reason.clone()))
+            }
+            _ => None,
         })
+    });
+    let kind = found
+        .as_ref()
+        .map(|(k, _)| *k)
         .unwrap_or(DisconnectKind::Forced);
 
     if matches!(kind, DisconnectKind::Forced) && err.0.is_empty() {
-        err.0 = "Disconnected from server. Press Esc to return to login.".into();
+        err.0 = match &found {
+            Some((_, reason)) => {
+                format!("Disconnected from server: {reason}\nPress Esc to return to login.")
+            }
+            None => "Disconnected from server. Press Esc to return to login.".into(),
+        };
     }
     tracing::info!(?kind, "disconnect-watcher: returning AppPhase to Launcher");
     next_phase.set(AppPhase::Launcher);

--- a/ffxi-client/src/view_native/mod.rs
+++ b/ffxi-client/src/view_native/mod.rs
@@ -438,6 +438,14 @@ pub fn run(args: NativeRunArgs) -> Result<()> {
         gamepad_input::gamepad_movement_camera_system.run_if(in_state(AppPhase::InGame)),
     );
 
+    // PreUpdate for the same reason: the pulsed ButtonInput press/release and
+    // the synthesized KeyboardInput both need to be visible before this
+    // frame's Update-schedule handle_input_system/text_input_system chain.
+    app.add_systems(
+        PreUpdate,
+        gamepad_input::gamepad_ingame_action_system.run_if(in_state(AppPhase::InGame)),
+    );
+
     app.add_systems(
         Update,
         (

--- a/ffxi-client/src/view_native/text_input.rs
+++ b/ffxi-client/src/view_native/text_input.rs
@@ -341,6 +341,14 @@ fn handle_world_key(
                     let r = ffxi_viewer_core::hud::action_model::NPC_INTERACT_YALMS;
                     dx * dx + dy * dy + dz * dz <= r * r
                 });
+                tracing::info!(
+                    target_id = id,
+                    entity_found = ent.is_some(),
+                    entity_kind = ?ent.map(|e| e.kind),
+                    is_npc,
+                    in_range,
+                    "confirm-action dispatch"
+                );
                 if is_npc {
                     if let (true, Some(ent)) = (in_range, ent) {
                         let _ = cmd_tx.try_send(AgentCommand::Action {

--- a/ffxi-client/src/view_native/text_input.rs
+++ b/ffxi-client/src/view_native/text_input.rs
@@ -2568,17 +2568,14 @@ fn handle_menu_key(
 
     if bindings.matches_logical(Action::NavUp, key) {
         let level = stack.current_mut()?;
-        level.cursor = if cursor == 0 {
-            entry_count.saturating_sub(1)
-        } else {
-            cursor - 1
-        };
+        level.cursor =
+            ffxi_viewer_core::hud::nav_geometry::list_step_wrapping(cursor, entry_count, -1);
         return None;
     }
     if bindings.matches_logical(Action::NavDown, key) {
         let level = stack.current_mut()?;
-        let next = cursor + 1;
-        level.cursor = if next >= entry_count { 0 } else { next };
+        level.cursor =
+            ffxi_viewer_core::hud::nav_geometry::list_step_wrapping(cursor, entry_count, 1);
         return None;
     }
     if bindings.matches_logical(Action::NavConfirm, key) {
@@ -2626,16 +2623,21 @@ fn handle_dialog_key(
         .unwrap_or(0)
         .min(ffxi_viewer_core::hud::dialog::MAX_OPTION_ROWS)
         .saturating_sub(1);
+    let count = max_index as usize + 1;
     if bindings.matches_logical(Action::NavUp, key) {
-        if cursor.cursor > 0 {
-            cursor.cursor -= 1;
-        }
+        cursor.cursor = ffxi_viewer_core::hud::nav_geometry::list_step_clamped(
+            cursor.cursor as usize,
+            count,
+            -1,
+        ) as u32;
         return None;
     }
     if bindings.matches_logical(Action::NavDown, key) {
-        if cursor.cursor < max_index {
-            cursor.cursor += 1;
-        }
+        cursor.cursor = ffxi_viewer_core::hud::nav_geometry::list_step_clamped(
+            cursor.cursor as usize,
+            count,
+            1,
+        ) as u32;
         return None;
     }
     if bindings.matches_logical(Action::NavConfirm, key) {
@@ -2710,16 +2712,13 @@ fn handle_quick_action_key(
 ) -> Option<InputMode> {
     let entry_count = ffxi_viewer_core::hud::quick_action::entry_count(state.has_target);
     if bindings.matches_logical(Action::NavUp, key) {
-        state.cursor = if state.cursor == 0 {
-            entry_count.saturating_sub(1)
-        } else {
-            state.cursor - 1
-        };
+        state.cursor =
+            ffxi_viewer_core::hud::nav_geometry::list_step_wrapping(state.cursor, entry_count, -1);
         return None;
     }
     if bindings.matches_logical(Action::NavDown, key) {
-        let next = state.cursor + 1;
-        state.cursor = if next >= entry_count { 0 } else { next };
+        state.cursor =
+            ffxi_viewer_core::hud::nav_geometry::list_step_wrapping(state.cursor, entry_count, 1);
         return None;
     }
     if bindings.matches_logical(Action::NavConfirm, key) {

--- a/ffxi-client/src/view_native/text_input.rs
+++ b/ffxi-client/src/view_native/text_input.rs
@@ -403,13 +403,15 @@ fn handle_target_action_key(
     select_target: &mut SelectTargetMode,
 ) -> Option<InputMode> {
     use ffxi_viewer_core::hud::action_model::{ActionEntryKind, TargetActionId};
-    use ffxi_viewer_core::input_mode::SubAction;
+    use ffxi_viewer_core::input_mode::{SubAction, TargetLevel};
 
     if trade_state.open {
         return handle_trade_key(key, bindings, trade_state, trade_intent, scene_state);
     }
 
-    if let Some(SubAction::AbilitiesGroup(group)) = state.sub.as_ref().and_then(|s| s.current()) {
+    if let Some(TargetLevel::Sub(SubAction::AbilitiesGroup(group))) =
+        state.stack.current().map(|l| l.kind)
+    {
         return handle_abilities_group_key(
             key,
             bindings,
@@ -427,25 +429,26 @@ fn handle_target_action_key(
     if count == 0 {
         return Some(InputMode::World);
     }
-    if state.cursor >= count {
-        state.cursor = count - 1;
+    let level = state.stack.current_mut()?;
+    if level.cursor >= count {
+        level.cursor = count - 1;
     }
 
     if bindings.matches_logical(Action::NavUp, key) {
-        state.cursor = if state.cursor == 0 {
-            count - 1
-        } else {
-            state.cursor - 1
-        };
+        let level = state.stack.current_mut()?;
+        level.cursor =
+            ffxi_viewer_core::hud::nav_geometry::list_step_wrapping(level.cursor, count, -1);
         return None;
     }
     if bindings.matches_logical(Action::NavDown, key) {
-        let next = state.cursor + 1;
-        state.cursor = if next >= count { 0 } else { next };
+        let level = state.stack.current_mut()?;
+        level.cursor =
+            ffxi_viewer_core::hud::nav_geometry::list_step_wrapping(level.cursor, count, 1);
         return None;
     }
     if bindings.matches_logical(Action::NavRight, key) {
-        if let Some(entry) = entries.get(state.cursor) {
+        let cursor = state.stack.current().map(|l| l.cursor).unwrap_or(0);
+        if let Some(entry) = entries.get(cursor) {
             if let ActionEntryKind::Select { modes, .. } = &entry.kind {
                 if !modes.is_empty() {
                     match entry.id {
@@ -619,7 +622,8 @@ fn confirm_target_action_at_cursor(
 ) -> Option<InputMode> {
     use ffxi_viewer_core::hud::action_model::TargetActionId;
 
-    let Some(entry) = entries.get(state.cursor) else {
+    let cursor = state.stack.current().map(|l| l.cursor).unwrap_or(0);
+    let Some(entry) = entries.get(cursor) else {
         return Some(InputMode::World);
     };
     if !entry.enabled {
@@ -670,9 +674,11 @@ fn confirm_target_action_at_cursor(
         TargetActionId::Magic => Some(open_submenu(MenuKind::Magic)),
         TargetActionId::Abilities => {
             use ffxi_viewer_core::hud::action_model::AbilityGroup;
-            use ffxi_viewer_core::input_mode::{SubAction, SubActionStack};
+            use ffxi_viewer_core::input_mode::{SubAction, TargetLevel};
             let group = AbilityGroup::ALL[state.abilities_group_idx % AbilityGroup::ALL.len()];
-            state.sub = Some(SubActionStack::with(SubAction::AbilitiesGroup(group)));
+            state
+                .stack
+                .push(TargetLevel::Sub(SubAction::AbilitiesGroup(group)));
             None
         }
         TargetActionId::Items => Some(open_submenu(MenuKind::Items)),
@@ -741,30 +747,30 @@ fn handle_abilities_group_key(
     let rows = ffxi_viewer_core::hud::menu::ability_group_rows(&scene_state.snapshot, group);
     let count = rows.len();
 
-    let sub = state.sub.as_mut()?;
-    if count > 0 && sub.cursor >= count {
-        sub.cursor = count - 1;
+    let level = state.stack.current_mut()?;
+    if count > 0 && level.cursor >= count {
+        level.cursor = count - 1;
     }
 
     if bindings.matches_logical(Action::NavUp, key) {
         if count > 0 {
-            sub.cursor = if sub.cursor == 0 {
-                count - 1
-            } else {
-                sub.cursor - 1
-            };
+            let level = state.stack.current_mut()?;
+            level.cursor =
+                ffxi_viewer_core::hud::nav_geometry::list_step_wrapping(level.cursor, count, -1);
         }
         return None;
     }
     if bindings.matches_logical(Action::NavDown, key) {
         if count > 0 {
-            let next = sub.cursor + 1;
-            sub.cursor = if next >= count { 0 } else { next };
+            let level = state.stack.current_mut()?;
+            level.cursor =
+                ffxi_viewer_core::hud::nav_geometry::list_step_wrapping(level.cursor, count, 1);
         }
         return None;
     }
     if bindings.matches_logical(Action::NavConfirm, key) {
-        if let Some(row) = rows.get(sub.cursor) {
+        let cursor = state.stack.current().map(|l| l.cursor).unwrap_or(0);
+        if let Some(row) = rows.get(cursor) {
             let self_pos = scene_state.snapshot.self_pos.pos;
             dispatch_dynamic_menu_action(
                 row.action,
@@ -780,9 +786,7 @@ fn handle_abilities_group_key(
         return None;
     }
     if bindings.matches_logical(Action::NavCancel, key) {
-        if !sub.pop() {
-            state.sub = None;
-        }
+        state.stack.pop();
         return None;
     }
     None
@@ -2434,7 +2438,9 @@ pub fn mouse_nav_dispatch_system(
 
     for ev in ta_events.read() {
         if let InputMode::TargetAction(state) = &mut *mode {
-            state.cursor = ev.slot;
+            if let Some(level) = state.stack.current_mut() {
+                level.cursor = ev.slot;
+            }
 
             let entries = ffxi_viewer_core::hud::overlay::RETAIL.resolve_target_actions(&state.ctx);
             if let Some(next) = confirm_target_action_at_cursor(

--- a/ffxi-client/src/view_native/text_input.rs
+++ b/ffxi-client/src/view_native/text_input.rs
@@ -730,6 +730,30 @@ fn confirm_target_action_at_cursor(
             push_system_chat_line(scene_state, "[menu] Trust — not implemented yet".into());
             Some(InputMode::World)
         }
+        TargetActionId::Open => {
+            match target_ent {
+                Some(e) => {
+                    // Doors are TYPE_NPC server-side (look.size == 0x02) and
+                    // trigger through the same Talk action_id as any other
+                    // NPC — vendor/server/src/map/packets/c2s/0x01a_action.cpp:198,213.
+                    // The server's own door script drives the yes/no confirm
+                    // and zone change; nothing door-specific is needed here.
+                    let cmd = AgentCommand::Action {
+                        target_id: e.id,
+                        target_index: e.act_index,
+                        kind: ActionKind::Talk,
+                    };
+                    if let Err(err) = cmd_tx.try_send(cmd) {
+                        push_system_chat_line(
+                            scene_state,
+                            format!("[menu] Open dispatch dropped: {err}"),
+                        );
+                    }
+                }
+                None => push_system_chat_line(scene_state, "[menu] Open: no target".to_string()),
+            }
+            Some(InputMode::World)
+        }
     }
 }
 

--- a/ffxi-client/src/view_native/text_input.rs
+++ b/ffxi-client/src/view_native/text_input.rs
@@ -2497,23 +2497,23 @@ fn handle_menu_key(
     // list navigation below.
     if matches!(kind, MenuKind::Items) {
         use ffxi_viewer_core::hud::item_detail::{apply_sort_option, SORT_OPTIONS};
-        if item_menu_focus.sort_focused {
+        if item_menu_focus.secondary_focused {
             let count = SORT_OPTIONS.len();
             if bindings.matches_logical(Action::NavUp, key) {
-                item_menu_focus.sort_cursor = if item_menu_focus.sort_cursor == 0 {
+                item_menu_focus.secondary_cursor = if item_menu_focus.secondary_cursor == 0 {
                     count - 1
                 } else {
-                    item_menu_focus.sort_cursor - 1
+                    item_menu_focus.secondary_cursor - 1
                 };
                 return None;
             }
             if bindings.matches_logical(Action::NavDown, key) {
-                let next = item_menu_focus.sort_cursor + 1;
-                item_menu_focus.sort_cursor = if next >= count { 0 } else { next };
+                let next = item_menu_focus.secondary_cursor + 1;
+                item_menu_focus.secondary_cursor = if next >= count { 0 } else { next };
                 return None;
             }
             if bindings.matches_logical(Action::NavConfirm, key) {
-                if let Some(&id) = SORT_OPTIONS.get(item_menu_focus.sort_cursor) {
+                if let Some(&id) = SORT_OPTIONS.get(item_menu_focus.secondary_cursor) {
                     apply_sort_option(sort_options, id);
                 }
                 if let Err(e) = cmd_tx.try_send(AgentCommand::StackInventory {
@@ -2526,14 +2526,14 @@ fn handle_menu_key(
             if bindings.matches_logical(Action::NavLeft, key)
                 || bindings.matches_logical(Action::NavCancel, key)
             {
-                item_menu_focus.sort_focused = false;
+                item_menu_focus.secondary_focused = false;
                 return None;
             }
             // Swallow any other key so it can't leak into list navigation.
             return None;
         } else if bindings.matches_logical(Action::NavRight, key) {
-            item_menu_focus.sort_focused = true;
-            item_menu_focus.sort_cursor = if sort_options.auto { 0 } else { 1 };
+            item_menu_focus.secondary_focused = true;
+            item_menu_focus.secondary_cursor = if sort_options.auto { 0 } else { 1 };
             return None;
         }
     }

--- a/ffxi-client/src/view_native/widgets/text_field.rs
+++ b/ffxi-client/src/view_native/widgets/text_field.rs
@@ -72,6 +72,17 @@ pub struct TextFieldPlugin;
 
 impl Plugin for TextFieldPlugin {
     fn build(&self, app: &mut App) {
+        // Gamescope's OSK paste gesture synthesizes Ctrl-down and V-down
+        // within the same PreUpdate tick, unlike a physical keyboard where
+        // they always land frames apart. Without this ordering, dispatch
+        // (which triggers text_field_on_key) can run before
+        // keyboard_input_system has recorded the Ctrl-down in
+        // `ButtonInput<KeyCode>`, so the paste's Ctrl+V reads as an
+        // unmodified 'V' and inserts a literal "v" instead of pasting.
+        app.configure_sets(
+            PreUpdate,
+            bevy::input_focus::InputFocusSystems::Dispatch.after(bevy::input::InputSystems),
+        );
         app.add_observer(text_field_on_key)
             .add_systems(Update, (sync_display, sync_focus_border, ime_commit_system));
     }

--- a/ffxi-client/src/view_native/widgets/text_field.rs
+++ b/ffxi-client/src/view_native/widgets/text_field.rs
@@ -123,16 +123,42 @@ fn ime_commit_system(
     }
 }
 
+/// Tracks Ctrl/Super held-state from the `FocusedInput<KeyboardInput>` stream
+/// itself rather than `Res<ButtonInput<KeyCode>>`. bevy_input_focus's
+/// `dispatch_focused_input` fires observers via a *deferred* `Commands::trigger`,
+/// so this observer only runs after `keyboard_input_system` has already
+/// processed the whole frame's raw key events. Gamescope's OSK paste
+/// synthesizes a full Ctrl+V chord (down/down/up/up) within a single frame, so
+/// by the time the deferred observer runs — for any of those four events —
+/// `ButtonInput<KeyCode>` already reflects Ctrl as released. Reconstructing
+/// modifier state from the events as this observer sees them, in their
+/// original per-event order, sidesteps that entirely.
+#[derive(Default)]
+struct KeyModifierTracker {
+    ctrl: bool,
+    super_: bool,
+}
+
 fn text_field_on_key(
     mut ev: On<FocusedInput<KeyboardInput>>,
     mut q: Query<&mut TextField>,
-    keys: Res<ButtonInput<KeyCode>>,
+    mut modifiers: Local<KeyModifierTracker>,
     mut commands: Commands,
 ) {
+    let input = &ev.event().input;
+    match input.key_code {
+        KeyCode::ControlLeft | KeyCode::ControlRight => {
+            modifiers.ctrl = input.state == ButtonState::Pressed;
+        }
+        KeyCode::SuperLeft | KeyCode::SuperRight => {
+            modifiers.super_ = input.state == ButtonState::Pressed;
+        }
+        _ => {}
+    }
+
     let Ok(mut field) = q.get_mut(ev.focused_entity) else {
         return;
     };
-    let input = &ev.event().input;
     if input.state != ButtonState::Pressed {
         return;
     }
@@ -141,20 +167,7 @@ fn text_field_on_key(
         return;
     }
 
-    let cmd_or_ctrl = keys.pressed(KeyCode::SuperLeft)
-        || keys.pressed(KeyCode::SuperRight)
-        || keys.pressed(KeyCode::ControlLeft)
-        || keys.pressed(KeyCode::ControlRight);
-    tracing::debug!(
-        key_code = ?input.key_code,
-        logical_key = ?input.logical_key,
-        cmd_or_ctrl,
-        ctrl_left = keys.pressed(KeyCode::ControlLeft),
-        ctrl_right = keys.pressed(KeyCode::ControlRight),
-        super_left = keys.pressed(KeyCode::SuperLeft),
-        super_right = keys.pressed(KeyCode::SuperRight),
-        "text_field: key event"
-    );
+    let cmd_or_ctrl = modifiers.ctrl || modifiers.super_;
     if cmd_or_ctrl {
         match input.key_code {
             KeyCode::KeyV => {

--- a/ffxi-client/src/view_native/widgets/text_field.rs
+++ b/ffxi-client/src/view_native/widgets/text_field.rs
@@ -7,6 +7,7 @@ use bevy::input_focus::tab_navigation::TabIndex;
 use bevy::input_focus::{FocusedInput, InputFocus};
 use bevy::prelude::*;
 use bevy::ui_widgets::ValueChange;
+use bevy::window::Ime;
 
 #[derive(Component, Default, Debug, Clone)]
 pub struct TextField {
@@ -72,7 +73,42 @@ pub struct TextFieldPlugin;
 impl Plugin for TextFieldPlugin {
     fn build(&self, app: &mut App) {
         app.add_observer(text_field_on_key)
-            .add_systems(Update, (sync_display, sync_focus_border));
+            .add_systems(Update, (sync_display, sync_focus_border, ime_commit_system));
+    }
+}
+
+/// Gamescope's on-screen keyboard (and other IME-driven virtual keyboards)
+/// inserts and pastes text via `Ime::Commit` rather than synthesizing
+/// `Ctrl+V`/per-character `KeyboardInput`, so it bypasses `text_field_on_key`
+/// entirely unless handled here too.
+fn ime_commit_system(
+    mut ime_events: MessageReader<Ime>,
+    focus: Option<Res<InputFocus>>,
+    mut q: Query<&mut TextField>,
+    mut commands: Commands,
+) {
+    let Some(focused) = focus.and_then(|f| f.0) else {
+        return;
+    };
+    for ev in ime_events.read() {
+        let Ime::Commit { value, .. } = ev else {
+            continue;
+        };
+        let Ok(mut field) = q.get_mut(focused) else {
+            continue;
+        };
+        let sanitized: String = value.chars().filter(|c| !c.is_control()).collect();
+        if sanitized.is_empty() {
+            continue;
+        }
+        let cur = field.cursor;
+        field.value.insert_str(cur, &sanitized);
+        field.cursor = cur + sanitized.len();
+        let value = field.value.clone();
+        commands.trigger(ValueChange {
+            source: focused,
+            value,
+        });
     }
 }
 

--- a/ffxi-client/src/view_native/widgets/text_field.rs
+++ b/ffxi-client/src/view_native/widgets/text_field.rs
@@ -145,6 +145,16 @@ fn text_field_on_key(
         || keys.pressed(KeyCode::SuperRight)
         || keys.pressed(KeyCode::ControlLeft)
         || keys.pressed(KeyCode::ControlRight);
+    tracing::debug!(
+        key_code = ?input.key_code,
+        logical_key = ?input.logical_key,
+        cmd_or_ctrl,
+        ctrl_left = keys.pressed(KeyCode::ControlLeft),
+        ctrl_right = keys.pressed(KeyCode::ControlRight),
+        super_left = keys.pressed(KeyCode::SuperLeft),
+        super_right = keys.pressed(KeyCode::SuperRight),
+        "text_field: key event"
+    );
     if cmd_or_ctrl {
         match input.key_code {
             KeyCode::KeyV => {

--- a/ffxi-client/src/view_native/widgets/text_field.rs
+++ b/ffxi-client/src/view_native/widgets/text_field.rs
@@ -1,7 +1,6 @@
 use bevy::feathers::theme::ThemeBackgroundColor;
 use bevy::feathers::tokens;
 use bevy::input::keyboard::{Key, KeyCode, KeyboardInput};
-use bevy::input::ButtonInput;
 use bevy::input::ButtonState;
 use bevy::input_focus::tab_navigation::TabIndex;
 use bevy::input_focus::{FocusedInput, InputFocus};

--- a/ffxi-dat/src/archive.rs
+++ b/ffxi-dat/src/archive.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
 
 use crate::ftable::{FTable, SubPath};
 use crate::vtable::VTable;
@@ -84,6 +85,24 @@ impl DatRoot {
             return Err(DatError::EnvMissing);
         }
         Self::open(fallback)
+    }
+
+    /// Process-lifetime-cached [`DatRoot`], built once from
+    /// [`Self::from_env_or_default`] and shared across every caller.
+    /// `DatRoot::open` does a real `fs::read` for every ROM's VTABLE+FTABLE
+    /// pair (up to [`MAX_ROM_INDEX`] of them), and the retail install path
+    /// never changes mid-process, so rebuilding it per call — as every
+    /// `ffxi-viewer-core` DAT-loading site used to — was pure waste.
+    pub fn shared() -> Result<Arc<Self>> {
+        static SHARED: OnceLock<std::result::Result<Arc<DatRoot>, String>> = OnceLock::new();
+        SHARED
+            .get_or_init(|| {
+                Self::from_env_or_default()
+                    .map(Arc::new)
+                    .map_err(|e| e.to_string())
+            })
+            .clone()
+            .map_err(DatError::Cached)
     }
 
     pub fn root(&self) -> &Path {

--- a/ffxi-dat/src/lib.rs
+++ b/ffxi-dat/src/lib.rs
@@ -85,6 +85,9 @@ pub enum DatError {
 
     #[error("FFXiMain.dll marker {hint:#010x} not found")]
     DllMarkerNotFound { hint: u32 },
+
+    #[error("{0}")]
+    Cached(String),
 }
 
 pub type Result<T> = std::result::Result<T, DatError>;

--- a/ffxi-event/src/vm.rs
+++ b/ffxi-event/src/vm.rs
@@ -59,6 +59,8 @@ const OP_REQSET: u8 = 0x27;
 const OP_REQSET_CHECKED: u8 = 0x28;
 const OP_REQSET_PRIORITY: u8 = 0x29;
 const OP_REQWAIT: u8 = 0x2A;
+const OP_LOADEXTSCHEDULER: u8 = 0x5B;
+const OP_LOADEXTSCHEDULER2: u8 = 0x66;
 const OP_SETBITWORK: u8 = 0x40;
 const OP_GETBITWORK: u8 = 0x41;
 const OP_SENDTAG: u8 = 0x43;
@@ -264,6 +266,13 @@ impl EventVm {
                 OP_REQSET | OP_REQSET_CHECKED | OP_REQSET_PRIORITY | OP_REQWAIT => {
                     self.exec_pointer += OPCODE_META[op as usize].size as usize;
                 }
+                // XiEvent LOADEXTSCHEDULER (research/XiEvents/OpCodes/0x005B.md,
+                // 0x0066.md): plays a motion between two actors, but always
+                // takes the "actor not found" early exit since this dialog-only
+                // VM models no actors.
+                OP_LOADEXTSCHEDULER | OP_LOADEXTSCHEDULER2 => {
+                    self.exec_pointer += OPCODE_META[op as usize].size as usize;
+                }
                 _ => {
                     let meta = OPCODE_META.get(op as usize).copied();
                     match meta {
@@ -435,6 +444,27 @@ mod tests {
         ] {
             assert_eq!(
                 OPCODE_META[op as usize].size as usize, size,
+                "op 0x{op:02X} size drifted from research/XiEvents/OpCodes"
+            );
+            let mut data = vec![op];
+            data.extend(std::iter::repeat_n(0u8, size - 1));
+            data.push(OP_END);
+            let mut e = vm(data, vec![]);
+            assert_eq!(
+                e.step(),
+                StepResult::Done,
+                "op 0x{op:02X} should run to END"
+            );
+            assert_eq!(e.exec_pointer(), size, "op 0x{op:02X} advanced wrong size");
+        }
+    }
+
+    #[test]
+    fn loadextscheduler_family_skips_by_size_and_continues() {
+        for op in [OP_LOADEXTSCHEDULER, OP_LOADEXTSCHEDULER2] {
+            let size = OPCODE_META[op as usize].size as usize;
+            assert_eq!(
+                size, 17,
                 "op 0x{op:02X} size drifted from research/XiEvents/OpCodes"
             );
             let mut data = vec![op];

--- a/ffxi-nav-recast/src/lib.rs
+++ b/ffxi-nav-recast/src/lib.rs
@@ -124,6 +124,11 @@ impl RecastNavMesh {
         Some(detour_to_ffxi(snapped).z)
     }
 
+    /// Coverage-check search extent for [`Self::slide_along`]'s off-mesh
+    /// fallback: wide enough to say "there is truly no navmesh data near
+    /// this destination", not just "no directly-connected polygon".
+    const COVERAGE_CHECK_EXT: [f32; 3] = [15.0, 100.0, 15.0];
+
     pub fn slide_along(&self, from: Vec3, to: Vec3) -> Option<Vec3> {
         let filter = DtQueryFilter::default();
         let start = ffxi_to_detour(from);
@@ -142,6 +147,26 @@ impl RecastNavMesh {
             .query
             .move_along_surface(start_ref, &snapped_start, &end, &filter, &mut visited)
             .ok()?;
+
+        // move_along_surface clamps to the connected-polygon boundary
+        // whenever `end` isn't reachable, and that's indistinguishable from
+        // its result alone between "a real wall/edge" and "LSB's xiNavmeshes
+        // bake (built for mob pathing, not full player-walkable coverage)
+        // simply never generated data out here". Treating the latter as a
+        // wall regresses walkable retail space (e.g. decorative plazas mobs
+        // never path through), so: if nothing exists near the *destination*
+        // even under a generous search, there's no data at all — return
+        // None so the caller's off-mesh fallback lets the raw move through
+        // instead of clamping to this edge.
+        let has_nearby_coverage = self
+            .query
+            .find_nearest_poly_1(&end, &Self::COVERAGE_CHECK_EXT, &filter)
+            .ok()
+            .is_some_and(|(poly_ref, _)| !poly_ref.is_null());
+        if !has_nearby_coverage {
+            return None;
+        }
+
         Some(detour_to_ffxi(result_d))
     }
 }

--- a/ffxi-viewer-core/examples/actor-render-headless.rs
+++ b/ffxi-viewer-core/examples/actor-render-headless.rs
@@ -268,7 +268,7 @@ fn spawn_subject(
 ) {
     let loaded = match &params.subject {
         Subject::Npc(id) => load_npc(*id),
-        Subject::Pc(race, equip) => load_pc(*race, equip, None, None),
+        Subject::Pc(race, equip) => load_pc(0, *race, equip, None, None),
     };
     match loaded {
         Ok(loaded) => {

--- a/ffxi-viewer-core/examples/actor-view.rs
+++ b/ffxi-viewer-core/examples/actor-view.rs
@@ -120,7 +120,7 @@ fn spawn_subject(
 ) {
     let loaded = match &*subject {
         Subject::Npc(id) => load_npc(*id),
-        Subject::Pc(race, equip) => load_pc(*race, equip, None, None),
+        Subject::Pc(race, equip) => load_pc(0, *race, equip, None, None),
     };
     match loaded {
         Ok(loaded) => {

--- a/ffxi-viewer-core/examples/zz-head-axis.rs
+++ b/ffxi-viewer-core/examples/zz-head-axis.rs
@@ -31,7 +31,7 @@ fn main() {
         load_npc(id).expect("load_npc failed")
     } else {
         let race: u8 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(1);
-        load_pc(race, &[], None, None).expect("load_pc failed")
+        load_pc(0, race, &[], None, None).expect("load_pc failed")
     };
     let skel = &loaded.skeleton;
 

--- a/ffxi-viewer-core/src/combat_stance.rs
+++ b/ffxi-viewer-core/src/combat_stance.rs
@@ -162,7 +162,7 @@ pub fn directional_anim_for_skel(skel_file_id: u32, prefix: &[u8; 3]) -> Option<
 }
 
 pub fn load_anim_with_prefix(file_id: u32, prefix: &[u8; 3]) -> Option<Mo2Animation> {
-    let root = DatRoot::from_env_or_default().ok()?;
+    let root = DatRoot::shared().ok()?;
     let loc = root.resolve(file_id).ok()?;
     let bytes = fs::read(loc.path_under(root.root())).ok()?;
     for chunk in walk(&bytes).filter_map(Result::ok) {
@@ -580,7 +580,7 @@ pub fn override_anim_for_skel(skel_file_id: u32, prefix: &[u8; 3]) -> Option<Arc
 }
 
 fn for_each_anim_chunk_in_dat(file_id: u32, mut f: impl FnMut(String, Mo2Animation)) {
-    let Ok(root) = DatRoot::from_env_or_default() else {
+    let Ok(root) = DatRoot::shared() else {
         return;
     };
     let Ok(loc) = root.resolve(file_id) else {
@@ -648,7 +648,7 @@ mod tests {
 
     #[test]
     fn battle_idle_resolves_for_every_pc_race_when_dats_available() {
-        if DatRoot::from_env_or_default().is_err() {
+        if DatRoot::shared().is_err() {
             eprintln!("skipping: no retail DAT root");
             return;
         }
@@ -663,7 +663,7 @@ mod tests {
 
     #[test]
     fn run_anim_resolves_for_every_pc_race_when_dats_available() {
-        if DatRoot::from_env_or_default().is_err() {
+        if DatRoot::shared().is_err() {
             eprintln!("skipping: no retail DAT root");
             return;
         }
@@ -874,7 +874,7 @@ mod tests {
 
     #[test]
     fn combat_run_resolves_with_higher_bone_count_than_casual() {
-        if DatRoot::from_env_or_default().is_err() {
+        if DatRoot::shared().is_err() {
             eprintln!("skipping: no retail DAT root");
             return;
         }

--- a/ffxi-viewer-core/src/cursor.rs
+++ b/ffxi-viewer-core/src/cursor.rs
@@ -4,6 +4,8 @@ use bevy::window::{CursorGrabMode, CursorOptions};
 use bevy::window::{CursorIcon, PrimaryWindow, SystemCursorIcon};
 
 #[cfg(not(target_arch = "wasm32"))]
+use crate::input_method::InputMethod;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::mouse::CursorLockRequest;
 use crate::mouse::MousePointer;
 use crate::picking::HoveredEntity;
@@ -106,6 +108,7 @@ fn apply_cursor_icon_system(
 fn apply_cursor_lock_system(
     style: Res<CursorStyle>,
     lock_request: Res<CursorLockRequest>,
+    method: Res<InputMethod>,
     win_q: Query<&Window, With<PrimaryWindow>>,
     mut opts_q: Query<&mut CursorOptions, With<PrimaryWindow>>,
 ) {
@@ -123,7 +126,7 @@ fn apply_cursor_lock_system(
     if opts.grab_mode != want_grab {
         opts.grab_mode = want_grab;
     }
-    let want_visible = !rotating;
+    let want_visible = !rotating && !matches!(*method, InputMethod::Gamepad);
     if opts.visible != want_visible {
         opts.visible = want_visible;
     }

--- a/ffxi-viewer-core/src/dat_mmb.rs
+++ b/ffxi-viewer-core/src/dat_mmb.rs
@@ -152,8 +152,7 @@ pub struct LoadedMmb {
 }
 
 pub fn load_mmb(file_id: u32, chunk_idx: usize) -> Result<LoadedMmb, String> {
-    let root =
-        DatRoot::from_env_or_default().map_err(|e| format!("DatRoot::from_env_or_default: {e}"))?;
+    let root = DatRoot::shared().map_err(|e| format!("DatRoot::shared: {e}"))?;
     let location = root
         .resolve(file_id)
         .map_err(|e| format!("resolve({file_id}): {e}"))?;

--- a/ffxi-viewer-core/src/dat_mzb.rs
+++ b/ffxi-viewer-core/src/dat_mzb.rs
@@ -1461,7 +1461,7 @@ pub fn auto_load_zone_geometry_system(
 
     for e in auto_q.iter() {
         if let Ok(mut ec) = commands.get_entity(e) {
-            ec.despawn();
+            ec.try_despawn();
         }
     }
 

--- a/ffxi-viewer-core/src/dat_mzb.rs
+++ b/ffxi-viewer-core/src/dat_mzb.rs
@@ -536,8 +536,7 @@ fn load_decrypted(
     file_id: u32,
     chunk_idx: Option<usize>,
 ) -> Result<(mzb::MzbHeader, Vec<u8>, ()), String> {
-    let root =
-        DatRoot::from_env_or_default().map_err(|e| format!("DatRoot::from_env_or_default: {e}"))?;
+    let root = DatRoot::shared().map_err(|e| format!("DatRoot::shared: {e}"))?;
     let location = root
         .resolve(file_id)
         .map_err(|e| format!("resolve({file_id}): {e}"))?;
@@ -586,8 +585,7 @@ pub fn build_zone_mmb_spawns(
     file_id: u32,
     chunk_idx: Option<usize>,
 ) -> Result<Vec<ZoneMmbSpawn>, String> {
-    let root =
-        DatRoot::from_env_or_default().map_err(|e| format!("DatRoot::from_env_or_default: {e}"))?;
+    let root = DatRoot::shared().map_err(|e| format!("DatRoot::shared: {e}"))?;
     let location = root
         .resolve(file_id)
         .map_err(|e| format!("resolve({file_id}): {e}"))?;
@@ -823,8 +821,7 @@ pub fn build_zone_mmb_spawns(
 }
 
 pub fn load_mzb(file_id: u32, chunk_idx: Option<usize>) -> Result<Vec<MzbSubMesh>, String> {
-    let root =
-        DatRoot::from_env_or_default().map_err(|e| format!("DatRoot::from_env_or_default: {e}"))?;
+    let root = DatRoot::shared().map_err(|e| format!("DatRoot::shared: {e}"))?;
     let location = root
         .resolve(file_id)
         .map_err(|e| format!("resolve({file_id}): {e}"))?;

--- a/ffxi-viewer-core/src/dat_mzb.rs
+++ b/ffxi-viewer-core/src/dat_mzb.rs
@@ -927,6 +927,12 @@ pub fn kick_load_mzb_tasks(
             let (submeshes, instances) = match load_mzb_placed(file_id, chunk_idx) {
                 Ok(s) => s,
                 Err(msg) => {
+                    warn!(
+                        file_id,
+                        ?chunk_idx,
+                        error = %msg,
+                        "load_mzb_placed: zone mesh load failed"
+                    );
                     return LoadedZoneGeom {
                         submeshes: Arc::new(Vec::new()),
                         instances: Arc::new(Vec::new()),
@@ -1168,15 +1174,14 @@ fn spawn_mzb_overlay(
     let submeshes: &[MzbSubMesh] = geom.submeshes.as_slice();
     let instances: &[MzbInstance] = geom.instances.as_slice();
     if submeshes.is_empty() || instances.is_empty() {
-        push_system_msg(
-            toasts,
-            format!(
-                "/load_mzb {}: 0 renderable meshes ({} submeshes, {} instances)",
-                req.file_id,
-                submeshes.len(),
-                instances.len(),
-            ),
-        );
+        let reason = match &geom.mmb_spawns {
+            Err(msg) => format!(": {msg}"),
+            Ok(_) => String::new(),
+        };
+        toasts.write(crate::snapshot::ToastEvent::system(format!(
+            "zone {}: mesh load failed, nothing will render here{reason}",
+            req.file_id,
+        )));
         return;
     }
 

--- a/ffxi-viewer-core/src/dat_mzb.rs
+++ b/ffxi-viewer-core/src/dat_mzb.rs
@@ -1488,10 +1488,9 @@ pub fn auto_load_zone_geometry_system(
             );
         }
         None => {
-            push_system_msg(
-                &mut toasts,
-                format!("auto-load: no DAT mapping for zone {zone_id} (Phase 11b table pending)"),
-            );
+            toasts.write(crate::snapshot::ToastEvent::system(format!(
+                "zone {zone_id}: no client-side geometry available, nothing will render here"
+            )));
         }
     }
 }

--- a/ffxi-viewer-core/src/dat_vos2.rs
+++ b/ffxi-viewer-core/src/dat_vos2.rs
@@ -64,7 +64,7 @@ pub struct LoadedVos2 {
 }
 
 pub fn enumerate_vos2_chunks(file_id: u32) -> Vec<usize> {
-    let Ok(root) = DatRoot::from_env_or_default() else {
+    let Ok(root) = DatRoot::shared() else {
         return Vec::new();
     };
     let Ok(loc) = root.resolve(file_id) else {
@@ -95,7 +95,7 @@ fn has_vos2_recursive(node: &ChunkNode<'_>) -> bool {
 }
 
 pub fn dat_has_skinned_mesh(file_id: u32) -> bool {
-    let Ok(root) = DatRoot::from_env_or_default() else {
+    let Ok(root) = DatRoot::shared() else {
         return false;
     };
     let Ok(loc) = root.resolve(file_id) else {
@@ -108,7 +108,7 @@ pub fn dat_has_skinned_mesh(file_id: u32) -> bool {
 }
 
 pub fn load_vos2(file_id: u32, chunk_idx: usize) -> Result<LoadedVos2, String> {
-    let root = DatRoot::from_env_or_default().map_err(|e| format!("DatRoot: {e}"))?;
+    let root = DatRoot::shared().map_err(|e| format!("DatRoot: {e}"))?;
     let location = root
         .resolve(file_id)
         .map_err(|e| format!("resolve({file_id}): {e}"))?;
@@ -198,7 +198,7 @@ fn baked_skeleton_for_file(file_id: u32) -> Option<BakedSkeleton> {
 }
 
 fn load_skeleton(file_id: u32) -> Option<BakedSkeleton> {
-    let root = DatRoot::from_env_or_default().ok()?;
+    let root = DatRoot::shared().ok()?;
     let loc = root.resolve(file_id).ok()?;
     let bytes = fs::read(loc.path_under(root.root())).ok()?;
     let chunks = walk(&bytes).filter_map(Result::ok);
@@ -258,7 +258,7 @@ fn load_skeleton(file_id: u32) -> Option<BakedSkeleton> {
 }
 
 fn load_idle_animation_for_file(file_id: u32) -> Option<ffxi_dat::anim::Mo2Animation> {
-    let root = DatRoot::from_env_or_default().ok()?;
+    let root = DatRoot::shared().ok()?;
     let loc = root.resolve(file_id).ok()?;
     let bytes = fs::read(loc.path_under(root.root())).ok()?;
     for chunk in walk(&bytes).filter_map(Result::ok) {

--- a/ffxi-viewer-core/src/ffxi_actor_render.rs
+++ b/ffxi-viewer-core/src/ffxi_actor_render.rs
@@ -331,7 +331,7 @@ fn first_skeleton(bytes: &[u8]) -> Option<Skeleton> {
 
 pub fn load_npc(file_id: u32) -> Result<LoadedActor, String> {
     crate::perf_probe::note_model_load();
-    let root = DatRoot::from_env_or_default().map_err(|e| format!("DatRoot: {e}"))?;
+    let root = DatRoot::shared().map_err(|e| format!("DatRoot: {e}"))?;
     let bytes = read_dat(&root, file_id).ok_or_else(|| format!("read npc dat {file_id}"))?;
 
     let skeleton =
@@ -395,7 +395,7 @@ pub fn load_pc(
 ) -> Result<LoadedActor, String> {
     crate::perf_probe::note_model_load();
     let _ = sub_weapon;
-    let root = DatRoot::from_env_or_default().map_err(|e| format!("DatRoot: {e}"))?;
+    let root = DatRoot::shared().map_err(|e| format!("DatRoot: {e}"))?;
     let race = if skeleton_file_id_for_race(race).is_some() {
         race
     } else {
@@ -2441,7 +2441,7 @@ mod pose_resolution_tests {
     }
 
     fn load_hume_m() -> Option<LoadedActor> {
-        if DatRoot::from_env_or_default().is_err() {
+        if DatRoot::shared().is_err() {
             eprintln!("skipping: no retail DAT root");
             return None;
         }

--- a/ffxi-viewer-core/src/ffxi_actor_render.rs
+++ b/ffxi-viewer-core/src/ffxi_actor_render.rs
@@ -377,6 +377,14 @@ fn default_pc_equipment(race: u8) -> Vec<u32> {
     out
 }
 
+/// Retail's PC race byte is only ever 1..=8 (`skeleton_file_id_for_race`'s
+/// table is exactly that size — there is no retail skeleton for anything
+/// else). An "Equipped"-look NPC broadcasting a race outside that range is
+/// bad server-side data, not a client gap; falling back to Hume Male here
+/// renders *a* humanoid instead of leaving the entity as a bare placeholder
+/// orb, at the cost of a wrong race/equipment fit for that one NPC.
+const FALLBACK_RACE: u8 = 1;
+
 pub fn load_pc(
     race: u8,
     equipment: &[u32],
@@ -387,6 +395,16 @@ pub fn load_pc(
     crate::perf_probe::note_model_load();
     let _ = sub_weapon;
     let root = DatRoot::from_env_or_default().map_err(|e| format!("DatRoot: {e}"))?;
+    let race = if skeleton_file_id_for_race(race).is_some() {
+        race
+    } else {
+        warn!(
+            race,
+            fallback = FALLBACK_RACE,
+            "load_pc: race has no retail skeleton, falling back"
+        );
+        FALLBACK_RACE
+    };
     let skel_file_id =
         skeleton_file_id_for_race(race).ok_or_else(|| format!("unsupported race {race}"))?;
 

--- a/ffxi-viewer-core/src/ffxi_actor_render.rs
+++ b/ffxi-viewer-core/src/ffxi_actor_render.rs
@@ -386,6 +386,7 @@ fn default_pc_equipment(race: u8) -> Vec<u32> {
 const FALLBACK_RACE: u8 = 1;
 
 pub fn load_pc(
+    entity_id: u32,
     race: u8,
     equipment: &[u32],
     main_weapon: Option<u32>,
@@ -399,9 +400,12 @@ pub fn load_pc(
         race
     } else {
         warn!(
+            entity_id,
             race,
+            equipment = ?equipment,
             fallback = FALLBACK_RACE,
-            "load_pc: race has no retail skeleton, falling back"
+            "load_pc: race has no retail skeleton, falling back — cross-check entity_id \
+             against the server's GetZone(id):getNPCs() to identify and fix the NPC's look data"
         );
         FALLBACK_RACE
     };
@@ -1656,6 +1660,7 @@ pub fn kick_load_actor_tasks(
             continue;
         }
         let subject = req.subject.clone();
+        let entity_id = req.entity_id;
         let task = AsyncComputeTaskPool::get().spawn(async move {
             let loaded = match subject {
                 ActorSubject::Npc { file_id } => load_npc(file_id),
@@ -1664,7 +1669,7 @@ pub fn kick_load_actor_tasks(
                     equipment,
                     main_weapon,
                     sub_weapon,
-                } => load_pc(race, &equipment, main_weapon, sub_weapon),
+                } => load_pc(entity_id, race, &equipment, main_weapon, sub_weapon),
             }?;
             let parts = prepare_actor_parts(&loaded, 0.0, 1.0, quality);
             Ok(PreparedActor { loaded, parts })
@@ -2441,7 +2446,7 @@ mod pose_resolution_tests {
             return None;
         }
 
-        Some(load_pc(1, &[], None, None).expect("load Hume M"))
+        Some(load_pc(0, 1, &[], None, None).expect("load Hume M"))
     }
 
     #[test]

--- a/ffxi-viewer-core/src/ffxi_actor_render.rs
+++ b/ffxi-viewer-core/src/ffxi_actor_render.rs
@@ -377,14 +377,6 @@ fn default_pc_equipment(race: u8) -> Vec<u32> {
     out
 }
 
-/// Retail's PC race byte is only ever 1..=8 (`skeleton_file_id_for_race`'s
-/// table is exactly that size — there is no retail skeleton for anything
-/// else). An "Equipped"-look NPC broadcasting a race outside that range is
-/// bad server-side data, not a client gap; falling back to Hume Male here
-/// renders *a* humanoid instead of leaving the entity as a bare placeholder
-/// orb, at the cost of a wrong race/equipment fit for that one NPC.
-const FALLBACK_RACE: u8 = 1;
-
 pub fn load_pc(
     entity_id: u32,
     race: u8,
@@ -396,21 +388,15 @@ pub fn load_pc(
     crate::perf_probe::note_model_load();
     let _ = sub_weapon;
     let root = DatRoot::shared().map_err(|e| format!("DatRoot: {e}"))?;
-    let race = if skeleton_file_id_for_race(race).is_some() {
-        race
-    } else {
-        warn!(
-            entity_id,
-            race,
-            equipment = ?equipment,
-            fallback = FALLBACK_RACE,
-            "load_pc: race has no retail skeleton, falling back — cross-check entity_id \
-             against the server's GetZone(id):getNPCs() to identify and fix the NPC's look data"
-        );
-        FALLBACK_RACE
-    };
-    let skel_file_id =
-        skeleton_file_id_for_race(race).ok_or_else(|| format!("unsupported race {race}"))?;
+    let skel_file_id = skeleton_file_id_for_race(race).ok_or_else(|| {
+        // Retail's PC race byte is only ever 1..=8 (skeleton_file_id_for_race's
+        // table is exactly that size) — a real server never sends anything
+        // else, so this is bad server-side NPC look data, not a client gap.
+        // entity_id + equipment let it be cross-checked against the server's
+        // GetZone(id):getNPCs() to find and fix the NPC's look data.
+        warn!(entity_id, race, equipment = ?equipment, "load_pc: race has no retail skeleton");
+        format!("unsupported race {race}")
+    })?;
 
     let skel_bytes =
         read_dat(&root, skel_file_id).ok_or_else(|| format!("read skel dat {skel_file_id}"))?;

--- a/ffxi-viewer-core/src/ffxi_actor_render.rs
+++ b/ffxi-viewer-core/src/ffxi_actor_render.rs
@@ -1711,7 +1711,7 @@ pub fn poll_load_actor_tasks(
         };
 
         if let Ok(FfxiRenderRoot(old_root)) = q_existing.get(wire_entity) {
-            commands.entity(*old_root).despawn();
+            commands.entity(*old_root).try_despawn();
         }
 
         let root = spawn_live_actor(
@@ -1824,7 +1824,7 @@ pub fn tick_morph_in(
                 tf.scale = Vec3::ONE;
             }
             if let Some(orb) = morph.orb {
-                commands.entity(orb).despawn();
+                commands.entity(orb).try_despawn();
             }
             commands
                 .entity(wire_entity)

--- a/ffxi-viewer-core/src/ffxi_actor_render.rs
+++ b/ffxi-viewer-core/src/ffxi_actor_render.rs
@@ -986,9 +986,12 @@ pub(crate) fn apply_character_shadow_cast(
     let mut apply = |e: Entity| {
         let mut ec = commands.entity(e);
         if cast {
-            ec.remove::<bevy::light::NotShadowCaster>();
+            // try_remove: this sweep can race an actor mesh despawning
+            // (e.g. the NPC left render range) between the query snapshot
+            // above and this command applying — an expected race, not a bug.
+            ec.try_remove::<bevy::light::NotShadowCaster>();
         } else {
-            ec.insert(bevy::light::NotShadowCaster);
+            ec.try_insert(bevy::light::NotShadowCaster);
         }
     };
     if settings.is_changed() {

--- a/ffxi-viewer-core/src/hud/action_model.rs
+++ b/ffxi-viewer-core/src/hud/action_model.rs
@@ -14,6 +14,7 @@ pub enum TargetActionId {
     Trade,
     Disengage,
     Check,
+    Open,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -111,6 +112,8 @@ fn applies_to(id: TargetActionId, kind: TargetKindLite, engaged: bool) -> bool {
         TargetActionId::Items => matches!(kind, None | Mob | Pc | SelfPc),
 
         TargetActionId::Trust => matches!(kind, None | Pc | SelfPc),
+
+        TargetActionId::Open => matches!(kind, Door),
     }
 }
 
@@ -121,6 +124,7 @@ pub fn build_target_action_entries(
     const ORDER: &[TargetActionId] = &[
         TargetActionId::SwitchTarget,
         TargetActionId::Attack,
+        TargetActionId::Open,
         TargetActionId::Chat,
         TargetActionId::Magic,
         TargetActionId::Abilities,
@@ -140,7 +144,10 @@ pub fn build_target_action_entries(
             continue;
         }
 
-        let needs_range = matches!(id, TargetActionId::Chat | TargetActionId::Trade);
+        let needs_range = matches!(
+            id,
+            TargetActionId::Chat | TargetActionId::Trade | TargetActionId::Open
+        );
         let out_of_range = needs_range && ctx.has_target && !ctx.in_range;
 
         let (kind, label) = match id {
@@ -172,6 +179,7 @@ pub fn build_target_action_entries(
             TargetActionId::Items => (ActionEntryKind::Plain, "Items".to_string()),
             TargetActionId::Trade => (ActionEntryKind::Plain, "Trade".to_string()),
             TargetActionId::Check => (ActionEntryKind::Plain, "Check".to_string()),
+            TargetActionId::Open => (ActionEntryKind::Plain, "Open".to_string()),
         };
 
         let hint = if out_of_range {
@@ -203,12 +211,16 @@ pub fn context_for_target(
     let ent = target_id.and_then(|id| entities.iter().find(|e| e.id == id));
     let (target_kind, in_range) = match ent {
         Some(e) => {
-            let kind = match e.kind {
-                EntityKind::Pc if Some(e.id) == self_id => TargetKindLite::SelfPc,
-                EntityKind::Pc => TargetKindLite::Pc,
-                EntityKind::Npc => TargetKindLite::Npc,
-                EntityKind::Mob => TargetKindLite::Mob,
-                EntityKind::Pet | EntityKind::Other => TargetKindLite::None,
+            let kind = if matches!(e.look, Some(ffxi_viewer_wire::EntityLook::Door { .. })) {
+                TargetKindLite::Door
+            } else {
+                match e.kind {
+                    EntityKind::Pc if Some(e.id) == self_id => TargetKindLite::SelfPc,
+                    EntityKind::Pc => TargetKindLite::Pc,
+                    EntityKind::Npc => TargetKindLite::Npc,
+                    EntityKind::Mob => TargetKindLite::Mob,
+                    EntityKind::Pet | EntityKind::Other => TargetKindLite::None,
+                }
             };
             let dx = e.pos.x - self_pos.x;
             let dy = e.pos.y - self_pos.y;

--- a/ffxi-viewer-core/src/hud/death_prompt.rs
+++ b/ffxi-viewer-core/src/hud/death_prompt.rs
@@ -2,13 +2,24 @@ use bevy::prelude::*;
 
 use crate::hud::palette;
 use crate::hud::self_hud::resolve_self;
+use crate::input_method::InputMethod;
 use crate::snapshot::SceneState;
 
 #[derive(Component)]
 pub struct DeathPromptPanel;
 
 #[derive(Component)]
+pub struct DeathPromptHint;
+
+#[derive(Component)]
 pub struct DeathCountdownText;
+
+fn hint_text(method: InputMethod) -> &'static str {
+    match method {
+        InputMethod::KeyboardMouse => "Press [Enter] to return to your home point.",
+        InputMethod::Gamepad => "Press [A] to return to your home point.",
+    }
+}
 
 const PANEL_WIDTH_PX: f32 = 380.0;
 
@@ -47,7 +58,8 @@ pub fn spawn_death_prompt(mut commands: Commands) {
                 TextColor(palette::STAGE_BAD),
             ));
             p.spawn((
-                Text::new("Press [Enter] to return to your home point."),
+                DeathPromptHint,
+                Text::new(hint_text(InputMethod::default())),
                 TextFont {
                     font_size: 13.0,
                     ..default()
@@ -81,9 +93,11 @@ pub struct DeathCountdownAnchor {
 pub fn update_death_prompt_system(
     time: Res<Time>,
     state: Res<SceneState>,
+    method: Res<InputMethod>,
     mut anchor: Local<DeathCountdownAnchor>,
     mut panel_q: Query<&mut Node, With<DeathPromptPanel>>,
     mut countdown_q: Query<&mut Text, With<DeathCountdownText>>,
+    mut hint_q: Query<&mut Text, (With<DeathPromptHint>, Without<DeathCountdownText>)>,
 ) {
     let snap = &state.snapshot;
 
@@ -119,6 +133,15 @@ pub fn update_death_prompt_system(
         };
         if **text != label {
             **text = label;
+        }
+    }
+
+    if method.is_changed() {
+        if let Ok(mut text) = hint_q.single_mut() {
+            let label = hint_text(*method);
+            if **text != label {
+                **text = label.to_string();
+            }
         }
     }
 }

--- a/ffxi-viewer-core/src/hud/equipment_screen.rs
+++ b/ffxi-viewer-core/src/hud/equipment_screen.rs
@@ -84,25 +84,11 @@ pub const EQUIP_GRID: [[EquipmentIndex; 4]; 4] = {
     ]
 };
 
-fn slot_to_cell(slot: EquipmentIndex) -> (usize, usize) {
-    for (r, row) in EQUIP_GRID.iter().enumerate() {
-        for (c, &s) in row.iter().enumerate() {
-            if s == slot {
-                return (r, c);
-            }
-        }
-    }
-    (0, 0)
-}
-
 /// Move the grid cursor (an internal slot index) by `dx` columns / `dy` rows,
 /// wrapping like the retail window. Used by the menu key handler.
 pub fn grid_move(slot: u8, dx: i32, dy: i32) -> u8 {
     let slot = EquipmentIndex::from_index(slot).unwrap_or(EquipmentIndex::Main);
-    let (r, c) = slot_to_cell(slot);
-    let nr = (r as i32 + dy).rem_euclid(EQUIP_GRID.len() as i32) as usize;
-    let nc = (c as i32 + dx).rem_euclid(EQUIP_GRID[0].len() as i32) as usize;
-    EQUIP_GRID[nr][nc] as u8
+    super::nav_geometry::grid_step(&EQUIP_GRID, slot, dx, dy) as u8
 }
 
 const DETAIL_ROWS: usize = 10;

--- a/ffxi-viewer-core/src/hud/equipment_screen.rs
+++ b/ffxi-viewer-core/src/hud/equipment_screen.rs
@@ -441,11 +441,9 @@ pub(crate) fn update_equipment_screen(
     let (detail_name, detail_rows) =
         item_ui::focus_detail(focused_item, snap, &dat_root, &mut icon_cache);
 
-    // Storage list viewport (keep the cursor in view).
     let storage_total = dynamic.rows.len();
-    let storage_start = storage_cursor
-        .saturating_sub(STORAGE_ROWS / 2)
-        .min(storage_total.saturating_sub(STORAGE_ROWS));
+    let storage_start =
+        super::nav_geometry::scroll_window(storage_cursor, storage_total, STORAGE_ROWS);
 
     for (tag, mut text, mut color, mut node) in text_q.iter_mut() {
         let (want, want_color, visible) = role_value(

--- a/ffxi-viewer-core/src/hud/item_detail.rs
+++ b/ffxi-viewer-core/src/hud/item_detail.rs
@@ -180,11 +180,7 @@ impl Default for SortOptions {
 /// Which pane of the Items window has keyboard focus. The item list owns focus
 /// by default; pressing NavRight moves it into the sort-options box so Auto /
 /// Manual become navigable, and NavLeft / NavCancel returns to the list.
-#[derive(Resource, Debug, Clone, Copy, Default)]
-pub struct ItemMenuFocus {
-    pub sort_focused: bool,
-    pub sort_cursor: usize,
-}
+pub type ItemMenuFocus = super::nav_geometry::PaneFocus;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SortOptionId {

--- a/ffxi-viewer-core/src/hud/item_screen.rs
+++ b/ffxi-viewer-core/src/hud/item_screen.rs
@@ -292,8 +292,8 @@ pub(crate) fn update_item_screen(
     }
     if !open {
         // Leaving the window drops sort focus so it reopens on the list.
-        if focus.sort_focused {
-            focus.sort_focused = false;
+        if focus.secondary_focused {
+            focus.secondary_focused = false;
         }
         return;
     }
@@ -433,7 +433,7 @@ fn role_value(
                     SortOptionId::Auto => sort.auto,
                     SortOptionId::Manual => !sort.auto,
                 };
-                let cursor = focus.sort_focused && focus.sort_cursor == i;
+                let cursor = focus.secondary_focused && focus.secondary_cursor == i;
                 let name = match id {
                     SortOptionId::Auto => "Auto",
                     SortOptionId::Manual => "Manual",
@@ -479,8 +479,8 @@ pub(crate) fn item_row_mouse_hover_system(
         if list_idx < total {
             // Hovering the list returns focus here, mirroring the sort box
             // grabbing it on hover — so neither pane traps the keyboard.
-            if focus.sort_focused {
-                focus.sort_focused = false;
+            if focus.secondary_focused {
+                focus.secondary_focused = false;
             }
             if level.cursor != list_idx {
                 level.cursor = list_idx;
@@ -533,12 +533,12 @@ pub(crate) fn sort_option_mouse_system(
         };
         match interaction {
             Interaction::Hovered => {
-                focus.sort_focused = true;
-                focus.sort_cursor = i;
+                focus.secondary_focused = true;
+                focus.secondary_cursor = i;
             }
             Interaction::Pressed => {
-                focus.sort_focused = true;
-                focus.sort_cursor = i;
+                focus.secondary_focused = true;
+                focus.secondary_cursor = i;
                 if let Some(&id) = SORT_OPTIONS.get(i) {
                     item_detail::apply_sort_option(&mut sort, id);
                 }

--- a/ffxi-viewer-core/src/hud/item_screen.rs
+++ b/ffxi-viewer-core/src/hud/item_screen.rs
@@ -68,14 +68,9 @@ fn items_cursor(mode: &InputMode) -> usize {
 }
 
 /// First visible list index, keeping `cursor` inside the `ITEM_LIST_ROWS`
-/// viewport. Mirrors `menu::resolve_viewport` so keyboard and mouse agree.
+/// viewport.
 pub fn viewport_start(cursor: usize, total: usize) -> usize {
-    if total <= ITEM_LIST_ROWS {
-        return 0;
-    }
-    let half = ITEM_LIST_ROWS / 2;
-    let max_start = total - ITEM_LIST_ROWS;
-    cursor.saturating_sub(half).min(max_start)
+    super::nav_geometry::scroll_window(cursor, total, ITEM_LIST_ROWS)
 }
 
 fn row_item_no(rows: &[crate::hud::menu::DynamicMenuRow], idx: usize) -> Option<u16> {

--- a/ffxi-viewer-core/src/hud/menu.rs
+++ b/ffxi-viewer-core/src/hud/menu.rs
@@ -819,4 +819,41 @@ mod tests {
             "the slot past the last field must be the Reset action"
         );
     }
+
+    /// Second proven consumer of the headless HUD test harness: spawns the
+    /// real Root menu, moves the cursor, and asserts the rendered row
+    /// text/color reflect it — the "does the cursor arrow land on the right
+    /// row" class of check the menu refactor could previously only verify
+    /// by hand.
+    #[test]
+    fn root_menu_row_text_and_color_follow_cursor() {
+        use crate::hud::test_harness::{headless_hud_app, set_mode_and_settle};
+        use crate::input_mode::MenuStack;
+
+        let mut app = headless_hud_app();
+        set_mode_and_settle(&mut app, InputMode::Menu(MenuStack::root()));
+
+        {
+            let mut mode = app.world_mut().resource_mut::<InputMode>();
+            let InputMode::Menu(stack) = &mut *mode else {
+                panic!("expected Menu mode");
+            };
+            stack.current_mut().expect("root level exists").cursor = 2;
+        }
+        app.update();
+        app.update();
+
+        let mut rows: Vec<(usize, String, Color)> = app
+            .world_mut()
+            .query::<(&MainMenuRow, &Text, &TextColor)>()
+            .iter(app.world())
+            .map(|(row, text, color)| (row.slot, text.0.clone(), color.0))
+            .collect();
+        rows.sort_by_key(|(slot, ..)| *slot);
+
+        assert_eq!(rows[0].1, "  Magic");
+        assert_eq!(rows[0].2, palette::MUTED);
+        assert_eq!(rows[2].1, "> Items");
+        assert_eq!(rows[2].2, palette::ACCENT);
+    }
 }

--- a/ffxi-viewer-core/src/hud/menu.rs
+++ b/ffxi-viewer-core/src/hud/menu.rs
@@ -606,13 +606,7 @@ fn visible_window(kind: MenuKind, total: usize) -> usize {
 fn resolve_viewport(kind: MenuKind, cursor: usize, dynamic: &DynamicMenu) -> (usize, usize) {
     if is_dynamic(kind) {
         let total = dynamic.rows.len().max(1);
-        if total <= DYNAMIC_VISIBLE_ROWS {
-            return (total, 0);
-        }
-
-        let half = DYNAMIC_VISIBLE_ROWS / 2;
-        let max_start = total.saturating_sub(DYNAMIC_VISIBLE_ROWS);
-        let start = cursor.saturating_sub(half).min(max_start);
+        let start = super::nav_geometry::scroll_window(cursor, total, DYNAMIC_VISIBLE_ROWS);
         (total, start)
     } else {
         (static_entries(kind).len(), 0)

--- a/ffxi-viewer-core/src/hud/mod.rs
+++ b/ffxi-viewer-core/src/hud/mod.rs
@@ -16,6 +16,7 @@ pub mod item_ui;
 pub mod logout_countdown;
 pub mod menu;
 pub mod mesh_debug;
+pub mod nav_geometry;
 pub mod network_status;
 pub mod overlay;
 pub mod quick_action;

--- a/ffxi-viewer-core/src/hud/mod.rs
+++ b/ffxi-viewer-core/src/hud/mod.rs
@@ -28,6 +28,8 @@ pub mod status_panel;
 pub mod status_ribbon;
 pub mod target_action_menu;
 pub mod target_panel;
+#[cfg(test)]
+mod test_harness;
 pub mod trade;
 pub mod vana_clock;
 pub mod weather_icon;

--- a/ffxi-viewer-core/src/hud/nav_geometry.rs
+++ b/ffxi-viewer-core/src/hud/nav_geometry.rs
@@ -14,6 +14,25 @@ pub fn scroll_window(cursor: usize, total: usize, visible_rows: usize) -> usize 
     cursor.saturating_sub(half).min(max_start)
 }
 
+/// Step a flat list cursor by `delta`, wrapping past either end (e.g. Up at
+/// row 0 lands on the last row). `count == 0` always yields `0`.
+pub fn list_step_wrapping(cursor: usize, count: usize, delta: i32) -> usize {
+    if count == 0 {
+        return 0;
+    }
+    (cursor as i32 + delta).rem_euclid(count as i32) as usize
+}
+
+/// Step a flat list cursor by `delta`, clamped at `0` and `count - 1` rather
+/// than wrapping (dialog choice lists use this — Up at the top choice stays
+/// put instead of jumping to the bottom). `count == 0` always yields `0`.
+pub fn list_step_clamped(cursor: usize, count: usize, delta: i32) -> usize {
+    if count == 0 {
+        return 0;
+    }
+    (cursor as i32 + delta).clamp(0, count as i32 - 1) as usize
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -33,5 +52,21 @@ mod tests {
         let mid = total / 2;
         assert_eq!(scroll_window(mid, total, rows), mid - rows / 2);
         assert_eq!(scroll_window(total - 1, total, rows), total - rows);
+    }
+
+    #[test]
+    fn list_step_wrapping_wraps_at_both_ends() {
+        assert_eq!(list_step_wrapping(0, 5, -1), 4);
+        assert_eq!(list_step_wrapping(4, 5, 1), 0);
+        assert_eq!(list_step_wrapping(2, 5, 1), 3);
+        assert_eq!(list_step_wrapping(0, 0, 1), 0);
+    }
+
+    #[test]
+    fn list_step_clamped_stops_at_both_ends() {
+        assert_eq!(list_step_clamped(0, 5, -1), 0);
+        assert_eq!(list_step_clamped(4, 5, 1), 4);
+        assert_eq!(list_step_clamped(2, 5, 1), 3);
+        assert_eq!(list_step_clamped(0, 0, 1), 0);
     }
 }

--- a/ffxi-viewer-core/src/hud/nav_geometry.rs
+++ b/ffxi-viewer-core/src/hud/nav_geometry.rs
@@ -1,0 +1,37 @@
+//! Pure navigation-geometry helpers shared by every drill-down/scrolling HUD
+//! menu, so the list/grid/pane math backing each menu's "layout kind" is
+//! implemented once rather than re-derived per menu.
+
+/// First visible row index for a `visible_rows`-tall scrolling window over a
+/// `total`-row list, centered on `cursor` and clamped so the window never
+/// runs past either end.
+pub fn scroll_window(cursor: usize, total: usize, visible_rows: usize) -> usize {
+    if total <= visible_rows {
+        return 0;
+    }
+    let half = visible_rows / 2;
+    let max_start = total - visible_rows;
+    cursor.saturating_sub(half).min(max_start)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scroll_window_keeps_short_lists_at_top() {
+        assert_eq!(scroll_window(0, 5, 13), 0);
+        assert_eq!(scroll_window(4, 5, 13), 0);
+        assert_eq!(scroll_window(0, 13, 13), 0);
+    }
+
+    #[test]
+    fn scroll_window_centers_and_clamps() {
+        let total = 40;
+        let rows = 13;
+        assert_eq!(scroll_window(0, total, rows), 0);
+        let mid = total / 2;
+        assert_eq!(scroll_window(mid, total, rows), mid - rows / 2);
+        assert_eq!(scroll_window(total - 1, total, rows), total - rows);
+    }
+}

--- a/ffxi-viewer-core/src/hud/nav_geometry.rs
+++ b/ffxi-viewer-core/src/hud/nav_geometry.rs
@@ -2,6 +2,17 @@
 //! menu, so the list/grid/pane math backing each menu's "layout kind" is
 //! implemented once rather than re-derived per menu.
 
+use bevy::prelude::Resource;
+
+/// Focus state for a dual-pane menu: a primary list plus a small secondary
+/// box (e.g. the Items window's sort-options box) that can steal keyboard
+/// focus. The primary pane owns focus by default.
+#[derive(Resource, Debug, Clone, Copy, Default)]
+pub struct PaneFocus {
+    pub secondary_focused: bool,
+    pub secondary_cursor: usize,
+}
+
 /// First visible row index for a `visible_rows`-tall scrolling window over a
 /// `total`-row list, centered on `cursor` and clamped so the window never
 /// runs past either end.

--- a/ffxi-viewer-core/src/hud/nav_geometry.rs
+++ b/ffxi-viewer-core/src/hud/nav_geometry.rs
@@ -33,6 +33,30 @@ pub fn list_step_clamped(cursor: usize, count: usize, delta: i32) -> usize {
     (cursor as i32 + delta).clamp(0, count as i32 - 1) as usize
 }
 
+/// Move a 2D grid cursor by `(dx, dy)` cells, wrapping past each edge.
+/// `table` is row-major (`table[row][col]`); `current` is searched for by
+/// value each call rather than tracked as a separate `(row, col)`, so grid
+/// menus can keep storing their cursor as the cell's own id type (e.g. an
+/// equipment slot enum) instead of a row/col pair.
+pub fn grid_step<const R: usize, const C: usize, T: Copy + PartialEq>(
+    table: &[[T; C]; R],
+    current: T,
+    dx: i32,
+    dy: i32,
+) -> T {
+    let mut cell = (0usize, 0usize);
+    for (r, row) in table.iter().enumerate() {
+        for (c, &t) in row.iter().enumerate() {
+            if t == current {
+                cell = (r, c);
+            }
+        }
+    }
+    let nr = (cell.0 as i32 + dy).rem_euclid(R as i32) as usize;
+    let nc = (cell.1 as i32 + dx).rem_euclid(C as i32) as usize;
+    table[nr][nc]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -68,5 +92,15 @@ mod tests {
         assert_eq!(list_step_clamped(4, 5, 1), 4);
         assert_eq!(list_step_clamped(2, 5, 1), 3);
         assert_eq!(list_step_clamped(0, 0, 1), 0);
+    }
+
+    #[test]
+    fn grid_step_wraps_and_steps() {
+        let table = [[0, 1, 2], [3, 4, 5]];
+        assert_eq!(grid_step(&table, 0, 1, 0), 1);
+        assert_eq!(grid_step(&table, 2, 1, 0), 0);
+        assert_eq!(grid_step(&table, 0, 0, 1), 3);
+        assert_eq!(grid_step(&table, 3, 0, 1), 0);
+        assert_eq!(grid_step(&table, 0, -1, 0), 2);
     }
 }

--- a/ffxi-viewer-core/src/hud/overlay.rs
+++ b/ffxi-viewer-core/src/hud/overlay.rs
@@ -23,6 +23,7 @@ pub enum MenuEntryId {
     TargetTrade,
     TargetDisengage,
     TargetCheck,
+    TargetOpen,
 }
 
 impl MenuEntryId {
@@ -38,6 +39,7 @@ impl MenuEntryId {
             TargetActionId::Trade => MenuEntryId::TargetTrade,
             TargetActionId::Disengage => MenuEntryId::TargetDisengage,
             TargetActionId::Check => MenuEntryId::TargetCheck,
+            TargetActionId::Open => MenuEntryId::TargetOpen,
         }
     }
 }

--- a/ffxi-viewer-core/src/hud/roster.rs
+++ b/ffxi-viewer-core/src/hud/roster.rs
@@ -111,7 +111,7 @@ pub fn update_roster_panel_system(
 
     if shape_changed {
         for (e, _) in &existing_rows {
-            commands.entity(*e).despawn();
+            commands.entity(*e).try_despawn();
         }
         commands.entity(panel).with_children(|p| {
             for member in party {

--- a/ffxi-viewer-core/src/hud/target_action_menu.rs
+++ b/ffxi-viewer-core/src/hud/target_action_menu.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use crate::hud::action_model::{ActionEntry, ActionEntryKind, TargetActionId};
 use crate::hud::overlay::ActiveOverlay;
 use crate::hud::palette;
-use crate::input_mode::{InputMode, SubAction};
+use crate::input_mode::{InputMode, SubAction, TargetLevel};
 
 const MAX_ROWS: usize = 7;
 
@@ -140,7 +140,10 @@ pub fn update_target_action_menu(
 
     panel.display = Display::Flex;
 
-    let sub_active = state.sub.as_ref().and_then(|s| s.current());
+    let sub_active = match state.stack.current().map(|l| l.kind) {
+        Some(TargetLevel::Sub(action)) => Some(action),
+        _ => None,
+    };
     if let Ok((mut node, mut text, mut color)) = crumb_q.single_mut() {
         match breadcrumb_text(sub_active) {
             Some(crumb) => {
@@ -179,11 +182,11 @@ pub fn update_target_action_menu(
             }
         }
     }
-    let cursor = state.cursor;
+    let cursor = state.stack.current().map(|l| l.cursor).unwrap_or(0);
 
     if let Some(SubAction::AbilitiesGroup(group)) = sub_active {
         let rows = crate::hud::menu::ability_group_rows(&scene.snapshot, group);
-        let sub_cursor = state.sub.as_ref().map(|s| s.cursor).unwrap_or(0);
+        let sub_cursor = cursor;
         for (row, mut node, mut text, mut color) in row_q.iter_mut() {
             let (want, want_color) = if rows.is_empty() {
                 if row.slot == 0 {
@@ -302,15 +305,21 @@ pub fn target_action_mouse_hover_system(
         return;
     };
 
-    if state.sub.as_ref().and_then(|s| s.current()).is_some() {
+    if matches!(
+        state.stack.current().map(|l| l.kind),
+        Some(TargetLevel::Sub(_))
+    ) {
         return;
     }
+    let Some(level) = state.stack.current_mut() else {
+        return;
+    };
     for (interaction, row) in &rows {
         if matches!(interaction, Interaction::Hovered | Interaction::Pressed)
             && row.slot < limit
-            && state.cursor != row.slot
+            && level.cursor != row.slot
         {
-            state.cursor = row.slot;
+            level.cursor = row.slot;
         }
     }
 }
@@ -325,7 +334,10 @@ pub fn target_action_mouse_click_system(
     let InputMode::TargetAction(state) = &*mode else {
         return;
     };
-    if state.sub.as_ref().and_then(|s| s.current()).is_some() {
+    if matches!(
+        state.stack.current().map(|l| l.kind),
+        Some(TargetLevel::Sub(_))
+    ) {
         return;
     }
     for (interaction, row) in &rows {

--- a/ffxi-viewer-core/src/hud/target_action_menu.rs
+++ b/ffxi-viewer-core/src/hud/target_action_menu.rs
@@ -440,4 +440,73 @@ mod tests {
         let crumb = breadcrumb_text(Some(SubAction::Items)).expect("crumb");
         assert!(crumb.contains("Items"));
     }
+
+    /// Drills into an ability group, then cancels back out one level at a
+    /// time — pinning that popping the Sub level lands back on the base
+    /// action list (breadcrumb hidden again), not a jump straight to World.
+    /// The old two-tier TargetActionState (a bare cursor plus an
+    /// Option<SubActionStack>) made this round-trip easy to get subtly wrong
+    /// during the NavStack<TargetLevel> migration; this is the regression
+    /// test that migration didn't have.
+    #[test]
+    fn drill_into_abilities_and_cancel_back_out() {
+        use crate::hud::action_model::AbilityGroup;
+        use crate::hud::test_harness::{headless_hud_app, set_mode_and_settle};
+        use crate::input_mode::{SubAction, TargetLevel};
+
+        let mut app = headless_hud_app();
+        set_mode_and_settle(
+            &mut app,
+            InputMode::TargetAction(TargetActionState::open(pc_ctx(true))),
+        );
+
+        {
+            let mut mode = app.world_mut().resource_mut::<InputMode>();
+            let InputMode::TargetAction(state) = &mut *mode else {
+                panic!("expected TargetAction mode");
+            };
+            state.stack.push(TargetLevel::Sub(SubAction::AbilitiesGroup(
+                AbilityGroup::JobAbilities,
+            )));
+        }
+        app.update();
+        app.update();
+
+        let (crumb_node, crumb_text) = app
+            .world_mut()
+            .query_filtered::<(&Node, &Text), With<TargetActionBreadcrumb>>()
+            .single(app.world())
+            .expect("breadcrumb entity exists");
+        assert_eq!(crumb_node.display, Display::Flex);
+        assert!(crumb_text.0.contains("Abilities"));
+        assert!(crumb_text.0.contains("Job Abilities"));
+
+        {
+            let mut mode = app.world_mut().resource_mut::<InputMode>();
+            let InputMode::TargetAction(state) = &mut *mode else {
+                panic!("expected TargetAction mode");
+            };
+            assert!(state.stack.pop(), "should pop back to Root, not empty out");
+            assert_eq!(
+                state.stack.current().map(|l| l.kind),
+                Some(TargetLevel::Root)
+            );
+        }
+        app.update();
+        app.update();
+
+        assert!(
+            matches!(
+                app.world().resource::<InputMode>(),
+                InputMode::TargetAction(_)
+            ),
+            "one cancel should stay inside the target-action menu, not exit to World"
+        );
+        let (crumb_node, _) = app
+            .world_mut()
+            .query_filtered::<(&Node, &Text), With<TargetActionBreadcrumb>>()
+            .single(app.world())
+            .expect("breadcrumb entity exists");
+        assert_eq!(crumb_node.display, Display::None);
+    }
 }

--- a/ffxi-viewer-core/src/hud/test_harness.rs
+++ b/ffxi-viewer-core/src/hud/test_harness.rs
@@ -1,0 +1,93 @@
+#![cfg(test)]
+
+use bevy::asset::AssetPlugin;
+use bevy::image::ImagePlugin;
+use bevy::input::InputPlugin;
+use bevy::picking::{InteractionPlugin, PickingPlugin};
+use bevy::prelude::*;
+use bevy::text::TextPlugin;
+use bevy::ui::UiPlugin;
+
+/// A headless `App` with the real `HudPlugin` wired up exactly like
+/// production (`add_hud_spawners` + `HudPlugin`), so tests exercise actual
+/// spawn/update systems rather than a re-implemented subset. No window, no
+/// GPU — `bevy_ui` layout and `bevy_text` shaping both run purely on CPU.
+pub(crate) fn headless_hud_app() -> App {
+    let mut app = App::new();
+    app.add_plugins((
+        MinimalPlugins,
+        AssetPlugin::default(),
+        ImagePlugin::default(),
+        InputPlugin,
+        TextPlugin,
+        // UiPlugin's viewport_picking system reads the HoverMap resource,
+        // owned by bevy_picking's InteractionPlugin — needed even though
+        // nothing in a headless test actually hovers anything. Skips
+        // DefaultPickingPlugins' PointerInputPlugin, which needs a real
+        // WindowPlugin-registered WindowEvent message this harness has none of.
+        PickingPlugin,
+        InteractionPlugin,
+        UiPlugin,
+    ));
+    // CursorMoved is normally registered by bevy_window's WindowPlugin, which
+    // this harness deliberately omits (no real window) — mouse::MousePlugin's
+    // collect_mouse_system still expects it to exist, even unused.
+    app.add_message::<bevy::window::CursorMoved>();
+    app.add_message::<crate::snapshot::ToastEvent>();
+    // UiPlugin's ImageNode content-sizing system expects this bevy_sprite
+    // asset type, normally registered by SpritePlugin (part of DefaultPlugins).
+    app.init_asset::<bevy::image::TextureAtlasLayout>();
+
+    // Resources HudPlugin's ~30 panel systems need but don't own themselves —
+    // normally supplied by ViewerCorePlugin in the real app. HudPlugin
+    // registers every panel into one Update schedule, so even though this
+    // harness only asserts on menu/target_action_menu, every other panel's
+    // systems still run each app.update() and need their resources present
+    // or the whole schedule panics (Bevy resource params are all-or-nothing
+    // per run, not just for the system under test).
+    app.init_resource::<crate::input_mode::InputMode>();
+    app.init_resource::<crate::snapshot::SceneState>();
+    app.init_resource::<crate::vana_time::VanaClock>();
+    app.init_resource::<crate::EventLog>();
+    app.init_resource::<crate::scene::TrackedEntities>();
+    app.init_resource::<crate::scene::Target>();
+    app.init_resource::<crate::keybinds::Bindings>();
+    app.init_resource::<crate::camera::CameraMode>();
+    app.init_resource::<crate::lock_on::LockOn>();
+    app.init_resource::<crate::zone_lines::ZoneLineState>();
+    app.init_resource::<crate::graphics_settings::GraphicsSettings>();
+    app.init_resource::<crate::hud::chat_panel::ChatScroll>();
+    app.init_resource::<crate::hud::chat_panel::BattleScroll>();
+    app.init_resource::<crate::hud::chat_panel::DebugScroll>();
+    app.init_resource::<crate::hud::chat_panel::ChatScrollAccum>();
+    app.init_resource::<crate::hud::chat_panel::BattleScrollAccum>();
+    app.init_resource::<crate::hud::chat_panel::DebugScrollAccum>();
+    app.init_resource::<crate::ui_font::UiFont>();
+    app.add_systems(Startup, crate::ui_font::load_ui_font);
+
+    app.add_plugins(crate::MousePlugin);
+    // entity_hover_card.rs reads these two (crate::picking::PickingPlugin's
+    // own resources) but crate::PickingPlugin itself pulls in
+    // bevy::picking::mesh_picking::MeshPickingPlugin, which needs
+    // Assets<Mesh> from bevy_render's MeshPlugin — real 3D-world click
+    // targeting this headless UI harness has no use for. Supply just the
+    // two Default resources directly instead of the whole plugin.
+    app.init_resource::<crate::picking::HoveredEntity>();
+    app.init_resource::<crate::picking::PickBridgePointer>();
+    app.add_plugins(crate::InputMethodPlugin);
+    app.add_plugins(crate::hud::HudPlugin);
+    crate::add_hud_spawners(&mut app, Startup);
+
+    app.update();
+    app
+}
+
+/// Set `InputMode` and run enough `Update` passes for it to propagate
+/// through the HUD's update systems (two covers dynamic-menu-row refresh ->
+/// render, which are ordered but split across two systems in one schedule).
+pub(crate) fn set_mode_and_settle(app: &mut App, mode: crate::input_mode::InputMode) {
+    *app.world_mut()
+        .resource_mut::<crate::input_mode::InputMode>() = mode;
+    app.update();
+    app.update();
+}

--- a/ffxi-viewer-core/src/input_method.rs
+++ b/ffxi-viewer-core/src/input_method.rs
@@ -1,0 +1,109 @@
+use bevy::input::gamepad::Gamepad;
+use bevy::input::mouse::{MouseMotion, MouseWheel};
+use bevy::prelude::*;
+
+const MOUSE_MOTION_ACTIVITY_PX: f32 = 2.0;
+
+const STICK_ACTIVITY_THRESHOLD: f32 = 0.5;
+
+#[derive(Resource, Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum InputMethod {
+    #[default]
+    KeyboardMouse,
+    Gamepad,
+}
+
+pub struct InputMethodPlugin;
+
+impl Plugin for InputMethodPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<InputMethod>()
+            .add_systems(PreUpdate, track_active_input_method_system);
+    }
+}
+
+fn track_active_input_method_system(
+    mut method: ResMut<InputMethod>,
+    keys: Res<ButtonInput<KeyCode>>,
+    mouse_buttons: Res<ButtonInput<MouseButton>>,
+    mut mouse_motion: MessageReader<MouseMotion>,
+    mut mouse_wheel: MessageReader<MouseWheel>,
+    gamepads: Query<&Gamepad>,
+) {
+    let motion_px_sq = MOUSE_MOTION_ACTIVITY_PX * MOUSE_MOTION_ACTIVITY_PX;
+    let keyboard_mouse_activity = keys.get_pressed().next().is_some()
+        || mouse_buttons.get_pressed().next().is_some()
+        || mouse_motion
+            .read()
+            .any(|e| e.delta.length_squared() > motion_px_sq)
+        || mouse_wheel.read().next().is_some();
+
+    if keyboard_mouse_activity {
+        *method = InputMethod::KeyboardMouse;
+        return;
+    }
+
+    let stick_sq = STICK_ACTIVITY_THRESHOLD * STICK_ACTIVITY_THRESHOLD;
+    let gamepad_activity = gamepads.iter().any(|g| {
+        g.get_pressed().next().is_some()
+            || g.left_stick().length_squared() > stick_sq
+            || g.right_stick().length_squared() > stick_sq
+    });
+    if gamepad_activity {
+        *method = InputMethod::Gamepad;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<MouseMotion>()
+            .add_message::<MouseWheel>()
+            .init_resource::<ButtonInput<KeyCode>>()
+            .init_resource::<ButtonInput<MouseButton>>()
+            .add_plugins(InputMethodPlugin);
+        app
+    }
+
+    #[test]
+    fn defaults_to_keyboard_mouse() {
+        let app = test_app();
+        assert_eq!(
+            *app.world().resource::<InputMethod>(),
+            InputMethod::KeyboardMouse
+        );
+    }
+
+    #[test]
+    fn held_key_keeps_keyboard_mouse_active() {
+        let mut app = test_app();
+        app.world_mut()
+            .resource_mut::<ButtonInput<KeyCode>>()
+            .press(KeyCode::KeyW);
+        app.update();
+        assert_eq!(
+            *app.world().resource::<InputMethod>(),
+            InputMethod::KeyboardMouse
+        );
+    }
+
+    #[test]
+    fn mouse_motion_below_threshold_is_ignored() {
+        let mut app = test_app();
+        app.world_mut()
+            .resource_mut::<InputMethod>()
+            .clone_from(&InputMethod::KeyboardMouse);
+        app.world_mut().write_message(MouseMotion {
+            delta: Vec2::new(0.1, 0.1),
+        });
+        app.update();
+        assert_eq!(
+            *app.world().resource::<InputMethod>(),
+            InputMethod::KeyboardMouse
+        );
+    }
+}

--- a/ffxi-viewer-core/src/input_mode.rs
+++ b/ffxi-viewer-core/src/input_mode.rs
@@ -65,37 +65,42 @@ pub enum MenuKind {
     EquipSlot(u8),
 }
 
+/// One entry in a `NavStack`: which sub-menu/sub-mode `K` is showing, and the
+/// list cursor it had the last time it was on top (restored on pop back to
+/// it, so backing out of a drilled-down level doesn't reset your place).
 #[derive(Debug, Clone)]
-pub struct MenuLevel {
-    pub kind: MenuKind,
+pub struct NavLevel<K> {
+    pub kind: K,
     pub cursor: usize,
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct MenuStack {
-    pub levels: Vec<MenuLevel>,
+/// A generic push/pop stack of navigable menu levels, shared by every
+/// drill-down menu in the HUD (the root pause menu keyed by `MenuKind`, the
+/// target-action menu keyed by `TargetLevel`) so scroll-window/list-cursor
+/// behavior — including per-level cursor memory across push/pop — only needs
+/// implementing once.
+#[derive(Debug, Clone)]
+pub struct NavStack<K> {
+    pub levels: Vec<NavLevel<K>>,
 }
 
-impl MenuStack {
-    pub fn root() -> Self {
+impl<K> NavStack<K> {
+    pub fn single(kind: K) -> Self {
         Self {
-            levels: vec![MenuLevel {
-                kind: MenuKind::Root,
-                cursor: 0,
-            }],
+            levels: vec![NavLevel { kind, cursor: 0 }],
         }
     }
 
-    pub fn current(&self) -> Option<&MenuLevel> {
+    pub fn current(&self) -> Option<&NavLevel<K>> {
         self.levels.last()
     }
 
-    pub fn current_mut(&mut self) -> Option<&mut MenuLevel> {
+    pub fn current_mut(&mut self) -> Option<&mut NavLevel<K>> {
         self.levels.last_mut()
     }
 
-    pub fn push(&mut self, kind: MenuKind) {
-        self.levels.push(MenuLevel { kind, cursor: 0 });
+    pub fn push(&mut self, kind: K) {
+        self.levels.push(NavLevel { kind, cursor: 0 });
     }
 
     pub fn pop(&mut self) -> bool {
@@ -105,6 +110,15 @@ impl MenuStack {
         } else {
             false
         }
+    }
+}
+
+pub type MenuLevel = NavLevel<MenuKind>;
+pub type MenuStack = NavStack<MenuKind>;
+
+impl MenuStack {
+    pub fn root() -> Self {
+        Self::single(MenuKind::Root)
     }
 }
 

--- a/ffxi-viewer-core/src/input_mode.rs
+++ b/ffxi-viewer-core/src/input_mode.rs
@@ -156,29 +156,6 @@ impl PassiveCursorState {
     }
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct TargetActionState {
-    pub cursor: usize,
-    pub ctx: crate::hud::action_model::TargetActionContext,
-    pub sub: Option<SubActionStack>,
-
-    pub chat_mode_idx: usize,
-
-    pub abilities_group_idx: usize,
-}
-
-impl TargetActionState {
-    pub fn open(ctx: crate::hud::action_model::TargetActionContext) -> Self {
-        Self {
-            cursor: 0,
-            ctx,
-            sub: None,
-            chat_mode_idx: 0,
-            abilities_group_idx: 0,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SubAction {
     MagicCategory(crate::hud::overlay::SpellCategory),
@@ -190,35 +167,32 @@ pub enum SubAction {
     ChatCompose,
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct SubActionStack {
-    pub frames: Vec<SubAction>,
-    pub cursor: usize,
+/// A level in the target-action menu's `NavStack`: either the base list of
+/// actions for the current target, or a drilled-down `SubAction` (e.g. an
+/// ability group's own list).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetLevel {
+    Root,
+    Sub(SubAction),
 }
 
-impl SubActionStack {
-    pub fn with(frame: SubAction) -> Self {
+#[derive(Debug, Clone)]
+pub struct TargetActionState {
+    pub stack: NavStack<TargetLevel>,
+    pub ctx: crate::hud::action_model::TargetActionContext,
+
+    pub chat_mode_idx: usize,
+
+    pub abilities_group_idx: usize,
+}
+
+impl TargetActionState {
+    pub fn open(ctx: crate::hud::action_model::TargetActionContext) -> Self {
         Self {
-            frames: vec![frame],
-            cursor: 0,
-        }
-    }
-
-    pub fn current(&self) -> Option<SubAction> {
-        self.frames.last().copied()
-    }
-
-    pub fn push(&mut self, frame: SubAction) {
-        self.frames.push(frame);
-        self.cursor = 0;
-    }
-
-    pub fn pop(&mut self) -> bool {
-        if self.frames.pop().is_some() {
-            self.cursor = 0;
-            !self.frames.is_empty()
-        } else {
-            false
+            stack: NavStack::single(TargetLevel::Root),
+            ctx,
+            chat_mode_idx: 0,
+            abilities_group_idx: 0,
         }
     }
 }

--- a/ffxi-viewer-core/src/lib.rs
+++ b/ffxi-viewer-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod ffxi_zone_material;
 pub mod graphics;
 pub use graphics::settings as graphics_settings;
 pub mod hud;
+pub mod input_method;
 pub mod input_mode;
 pub mod keybinds;
 pub mod lens_flare;
@@ -88,6 +89,7 @@ pub use graphics_settings::{
     SkyStyle, TextureFiltering, ZoneLineDisplay, GRAPHICS_FIELDS,
 };
 pub use hud::{add_hud_spawners, HudPlugin};
+pub use input_method::{InputMethod, InputMethodPlugin};
 pub use input_mode::{
     ChatBuffer, DialogCursor, InputMode, MenuKind, MenuLevel, MenuStack, PassiveCursorFocus,
     PassiveCursorState, QuickActionState, DIALOG_MAX_CHOICE,
@@ -232,6 +234,7 @@ impl<S: SceneSource + Resource> Plugin for ViewerCorePlugin<S> {
             .init_resource::<ui_font::UiFont>()
             .add_plugins(PickingPlugin)
             .add_plugins(CursorPlugin)
+            .add_plugins(InputMethodPlugin)
             .add_message::<ToastEvent>()
             .add_systems(Startup, ui_font::load_ui_font)
             .add_systems(Update, ui_font::apply_ui_font)

--- a/ffxi-viewer-core/src/minimap/overlay.rs
+++ b/ffxi-viewer-core/src/minimap/overlay.rs
@@ -116,7 +116,7 @@ pub fn update_minimap_overlay(
     for id in stale {
         if let Some(dot_entity) = dots.by_id.remove(&id) {
             if let Ok(mut ec) = commands.get_entity(dot_entity) {
-                ec.despawn();
+                ec.try_despawn();
             }
         }
     }

--- a/ffxi-viewer-core/src/nameplate.rs
+++ b/ffxi-viewer-core/src/nameplate.rs
@@ -139,7 +139,10 @@ pub fn update_nameplates_system(
                 }
             }
             None => {
-                commands.entity(ui_entity).despawn();
+                // try_despawn: this entity's correlated world entity may
+                // have already been removed by a bulk zone-transition
+                // despawn this same frame — an expected race, not a bug.
+                commands.entity(ui_entity).try_despawn();
             }
         }
     }

--- a/ffxi-viewer-core/src/nameplate_billboard.rs
+++ b/ffxi-viewer-core/src/nameplate_billboard.rs
@@ -182,7 +182,10 @@ pub fn update_nameplate_billboards_system(
 
     for (ui_entity, mut np, mut aspect, mut transform, mut vis, mat) in &mut billboards {
         let Some(&(entity_pos, head_y_offset)) = pos_by_id.get(&np.entity_id) else {
-            commands.entity(ui_entity).despawn();
+            // try_despawn: this billboard's correlated world entity may have
+            // already been removed by a bulk zone-transition despawn this
+            // same frame — an expected race, not a bug.
+            commands.entity(ui_entity).try_despawn();
             continue;
         };
 

--- a/ffxi-viewer-core/src/particle_sim.rs
+++ b/ffxi-viewer-core/src/particle_sim.rs
@@ -203,7 +203,7 @@ pub fn sync_particle_meshes(
 
     for &i in dead.iter().rev() {
         let g = sim.generators.swap_remove(i);
-        commands.entity(g.entity).despawn();
+        commands.entity(g.entity).try_despawn();
     }
 }
 

--- a/ffxi-viewer-core/src/scene.rs
+++ b/ffxi-viewer-core/src/scene.rs
@@ -193,6 +193,12 @@ pub fn setup_world(
     });
 }
 
+#[derive(Default)]
+pub struct SyncEntitiesDiag {
+    prev_zone: Option<Option<u16>>,
+    last_logged_total: Option<usize>,
+}
+
 pub fn sync_entities_system(
     state: Res<SceneState>,
     mesh: Res<EntityMesh>,
@@ -209,7 +215,7 @@ pub fn sync_entities_system(
     mut q_xform: Query<&mut Transform, With<WorldEntity>>,
     mut q_mat: Query<&mut MeshMaterial3d<StandardMaterial>, (With<WorldEntity>, Without<MorphIn>)>,
     q_nameplates: Query<&Nameplate>,
-    mut prev_zone: Local<Option<Option<u16>>>,
+    mut sync_diag: Local<SyncEntitiesDiag>,
 ) {
     if !state.dirty {
         return;
@@ -217,10 +223,17 @@ pub fn sync_entities_system(
 
     let snap = &state.snapshot;
 
-    let zone_changed = matches!(*prev_zone, Some(p) if p != snap.zone_id);
-    *prev_zone = Some(snap.zone_id);
-
+    let zone_changed = matches!(sync_diag.prev_zone, Some(p) if p != snap.zone_id);
     if zone_changed {
+        sync_diag.last_logged_total = None;
+    }
+    sync_diag.prev_zone = Some(snap.zone_id);
+
+    // Logged on every entity-count change (not just the zone-entry instant)
+    // so the initial zone-in flood settling in over several updates is
+    // actually captured, not just the near-empty first frame.
+    if sync_diag.last_logged_total != Some(snap.entities.len()) {
+        sync_diag.last_logged_total = Some(snap.entities.len());
         let mut pc = 0u32;
         let mut npc = 0u32;
         let mut mob = 0u32;
@@ -243,7 +256,7 @@ pub fn sync_entities_system(
             mob,
             pet,
             other,
-            "sync_entities_system: entity-kind breakdown on zone entry"
+            "sync_entities_system: entity-kind breakdown changed"
         );
     }
 

--- a/ffxi-viewer-core/src/scene.rs
+++ b/ffxi-viewer-core/src/scene.rs
@@ -220,6 +220,33 @@ pub fn sync_entities_system(
     let zone_changed = matches!(*prev_zone, Some(p) if p != snap.zone_id);
     *prev_zone = Some(snap.zone_id);
 
+    if zone_changed {
+        let mut pc = 0u32;
+        let mut npc = 0u32;
+        let mut mob = 0u32;
+        let mut pet = 0u32;
+        let mut other = 0u32;
+        for e in &snap.entities {
+            match e.kind {
+                EntityKind::Pc => pc += 1,
+                EntityKind::Npc => npc += 1,
+                EntityKind::Mob => mob += 1,
+                EntityKind::Pet => pet += 1,
+                EntityKind::Other => other += 1,
+            }
+        }
+        info!(
+            zone_id = ?snap.zone_id,
+            total = snap.entities.len(),
+            pc,
+            npc,
+            mob,
+            pet,
+            other,
+            "sync_entities_system: entity-kind breakdown on zone entry"
+        );
+    }
+
     let mut nameplated: std::collections::HashSet<u32> =
         q_nameplates.iter().map(|n| n.entity_id).collect();
 

--- a/ffxi-viewer-core/src/scene.rs
+++ b/ffxi-viewer-core/src/scene.rs
@@ -348,7 +348,11 @@ pub fn sync_entities_system(
         .collect();
     for id in stale {
         if let Some(bevy_e) = tracked.by_id.remove(&id) {
-            commands.entity(bevy_e).despawn();
+            // try_despawn, not despawn: a bulk zone-transition despawn
+            // (despawn_ingame_entities, OnExit(AppPhase::InGame)) can beat
+            // this per-entity cleanup to the same entity in the same frame —
+            // an expected race, not a bug, so this shouldn't warn.
+            commands.entity(bevy_e).try_despawn();
         }
 
         prediction.by_id.remove(&id);

--- a/ffxi-viewer-core/src/scheduler_runtime.rs
+++ b/ffxi-viewer-core/src/scheduler_runtime.rs
@@ -353,7 +353,7 @@ pub fn dispatch_action_started(
         // FFXiMain.dll is only needed for weaponskill base indices; load it lazily once.
         if action_kind == 3 && !dll_cache.loaded {
             dll_cache.loaded = true;
-            if let Ok(root) = ffxi_dat::DatRoot::from_env_or_default() {
+            if let Ok(root) = ffxi_dat::DatRoot::shared() {
                 dll_cache.dll = ffxi_dat::main_dll::MainDll::load(root.root()).ok();
             }
         }
@@ -363,7 +363,7 @@ pub fn dispatch_action_started(
             continue;
         };
 
-        let Ok(root) = ffxi_dat::DatRoot::from_env_or_default() else {
+        let Ok(root) = ffxi_dat::DatRoot::shared() else {
             continue;
         };
         let Ok(loc) = root.resolve(file_id) else {

--- a/ffxi-viewer-core/src/weather.rs
+++ b/ffxi-viewer-core/src/weather.rs
@@ -177,7 +177,7 @@ pub fn load_zone_weather(
         return;
     };
 
-    let Ok(root) = DatRoot::from_env_or_default() else {
+    let Ok(root) = DatRoot::shared() else {
         return;
     };
     let Ok(location) = root.resolve(file_id) else {

--- a/ffxi-viewer-core/src/weather_fx.rs
+++ b/ffxi-viewer-core/src/weather_fx.rs
@@ -439,7 +439,7 @@ pub fn manage_weather_particles_system(
     }
 
     for (e, _) in q_root.iter() {
-        commands.entity(e).despawn();
+        commands.entity(e).try_despawn();
     }
 
     let Some(profile) = active.modifier.particle else {

--- a/ffxi-viewer-core/src/zone_clouds.rs
+++ b/ffxi-viewer-core/src/zone_clouds.rs
@@ -397,7 +397,7 @@ fn rebuild_zone_clouds(
     let Some(file_id) = ffxi_dat::zone_dat::zone_id_to_mzb_file_id(zone_id) else {
         return;
     };
-    let Ok(root) = DatRoot::from_env_or_default() else {
+    let Ok(root) = DatRoot::shared() else {
         return;
     };
     let Ok(location) = root.resolve(file_id) else {
@@ -558,7 +558,7 @@ fn rebuild_zone_stars(
     let Some(file_id) = ffxi_dat::zone_dat::zone_id_to_mzb_file_id(zone_id) else {
         return;
     };
-    let Ok(root) = DatRoot::from_env_or_default() else {
+    let Ok(root) = DatRoot::shared() else {
         return;
     };
     let Ok(location) = root.resolve(file_id) else {

--- a/ffxi-viewer-core/src/zone_clouds.rs
+++ b/ffxi-viewer-core/src/zone_clouds.rs
@@ -386,7 +386,7 @@ fn rebuild_zone_clouds(
                 elapsed: 0.0,
             });
         } else {
-            commands.entity(e).despawn();
+            commands.entity(e).try_despawn();
         }
     }
     state.key = key;
@@ -491,7 +491,7 @@ fn drive_zone_clouds(
         fade.elapsed += dt;
         if fade.finished_out() {
             state.entities.retain(|&e| e != entity);
-            commands.entity(entity).despawn();
+            commands.entity(entity).try_despawn();
             continue;
         }
 
@@ -548,7 +548,7 @@ fn rebuild_zone_stars(
         return;
     }
     if let Some(e) = state.entity.take() {
-        commands.entity(e).despawn();
+        commands.entity(e).try_despawn();
     }
     state.zone = zone_id;
 

--- a/ffxi-viewer-core/src/zone_lines.rs
+++ b/ffxi-viewer-core/src/zone_lines.rs
@@ -100,7 +100,7 @@ pub fn sync_zone_lines_system(
     }
 
     for e in &existing {
-        commands.entity(e).despawn();
+        commands.entity(e).try_despawn();
     }
     zl_state.current_zone = Some(zone_id);
     zl_state.current_mode = Some(mode);

--- a/ffxi-viewer-core/src/zone_point_lights.rs
+++ b/ffxi-viewer-core/src/zone_point_lights.rs
@@ -222,7 +222,7 @@ fn load_zone_point_lights(scene_state: Res<SceneState>, mut store: ResMut<ZonePo
     let Some(file_id) = zone_dat::zone_id_to_mzb_file_id(zone_id) else {
         return;
     };
-    let Ok(root) = DatRoot::from_env_or_default() else {
+    let Ok(root) = DatRoot::shared() else {
         return;
     };
     let Ok(loc) = root.resolve(file_id) else {

--- a/ffxi-viewer-core/src/zone_point_lights.rs
+++ b/ffxi-viewer-core/src/zone_point_lights.rs
@@ -280,7 +280,7 @@ fn sync_faithful_zone_light_entities(
         return;
     }
     for e in &existing {
-        commands.entity(e).despawn();
+        commands.entity(e).try_despawn();
     }
     for l in &store.lights {
         if l.is_character {

--- a/scripts/install-deck.sh
+++ b/scripts/install-deck.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Build a release ffxi-client and install it for local use on this machine
+# (Steam Deck or otherwise): copies the binary to ~/.local/bin and adds a
+# .desktop entry so it shows up in the app menu / can be added as a Steam
+# non-Steam-game shortcut. Credentials and FFXI_DAT_PATH are left for the
+# launcher's own interactive prompts (see AGENTS.md "Running") rather than
+# baked into the desktop entry.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+echo "building release binary (LLVM backend, this takes a while)..."
+cargo build -p ffxi-client --release --features native-window
+
+bin_dir="$HOME/.local/bin"
+mkdir -p "$bin_dir"
+install -m 755 target/release/ffxi-client "$bin_dir/ffxi-client"
+echo "installed: $bin_dir/ffxi-client"
+
+desktop_dir="$HOME/.local/share/applications"
+mkdir -p "$desktop_dir"
+desktop_file="$desktop_dir/kuluu-ffxi.desktop"
+cat > "$desktop_file" <<EOF
+[Desktop Entry]
+Type=Application
+Name=Kuluu FFXI
+Comment=Open-source FFXI client for LandSandBoat/Phoenix private servers
+Exec=$bin_dir/ffxi-client play
+Terminal=false
+Categories=Game;
+EOF
+echo "installed: $desktop_file"
+
+case ":$PATH:" in
+    *":$bin_dir:"*) ;;
+    *) echo "note: $bin_dir is not on PATH — add it to your shell profile to run 'ffxi-client' directly" ;;
+esac
+
+echo "done. Launch via the app menu, or 'ffxi-client play' if $bin_dir is on PATH."

--- a/scripts/install-deck.sh
+++ b/scripts/install-deck.sh
@@ -1,38 +1,24 @@
 #!/usr/bin/env bash
-# Build a release ffxi-client and install it for local use on this machine
-# (Steam Deck or otherwise): copies the binary to ~/.local/bin and adds a
-# .desktop entry so it shows up in the app menu / can be added as a Steam
-# non-Steam-game shortcut. Credentials and FFXI_DAT_PATH are left for the
-# launcher's own interactive prompts (see AGENTS.md "Running") rather than
-# baked into the desktop entry.
+# Build a release ffxi-client and drop it into the existing local install
+# layout (~/.local/share/kuluu-ffxi/bin/ffxi-client), which the
+# ~/.local/bin/kuluu-ffxi wrapper script and its Steam non-Steam-game
+# shortcut already point at. Only updates the binary in place — doesn't
+# touch the wrapper script, .desktop entry, or Steam shortcut config, since
+# those already exist and work.
 set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 echo "building release binary (LLVM backend, this takes a while)..."
 cargo build -p ffxi-client --release --features native-window
 
-bin_dir="$HOME/.local/bin"
-mkdir -p "$bin_dir"
-install -m 755 target/release/ffxi-client "$bin_dir/ffxi-client"
-echo "installed: $bin_dir/ffxi-client"
+install_dir="$HOME/.local/share/kuluu-ffxi/bin"
+mkdir -p "$install_dir"
+install -m 755 target/release/ffxi-client "$install_dir/ffxi-client"
+echo "installed: $install_dir/ffxi-client"
 
-desktop_dir="$HOME/.local/share/applications"
-mkdir -p "$desktop_dir"
-desktop_file="$desktop_dir/kuluu-ffxi.desktop"
-cat > "$desktop_file" <<EOF
-[Desktop Entry]
-Type=Application
-Name=Kuluu FFXI
-Comment=Open-source FFXI client for LandSandBoat/Phoenix private servers
-Exec=$bin_dir/ffxi-client play
-Terminal=false
-Categories=Game;
-EOF
-echo "installed: $desktop_file"
-
-case ":$PATH:" in
-    *":$bin_dir:"*) ;;
-    *) echo "note: $bin_dir is not on PATH — add it to your shell profile to run 'ffxi-client' directly" ;;
-esac
-
-echo "done. Launch via the app menu, or 'ffxi-client play' if $bin_dir is on PATH."
+wrapper="$HOME/.local/bin/kuluu-ffxi"
+if [ -x "$wrapper" ]; then
+    echo "existing launcher wrapper found: $wrapper (unchanged)"
+else
+    echo "note: no launcher wrapper at $wrapper — launch $install_dir/ffxi-client directly, or create one"
+fi


### PR DESCRIPTION
## Summary

The launcher UI (login/char-select/settings/etc.) and in-game movement/camera were keyboard+mouse only despite `gilrs` already detecting the Steam Deck's built-in controller (and an Xbox pad) at the input-plugin level - nothing in the app actually consumed that input, so a Deck user in Game Mode with no keyboard/mouse attached couldn't get past the login screen.

- **Launcher UI**: D-pad drives focus via the same `TabNavigation` system param `bevy_input_focus`'s own Tab-key handler uses internally, and South is re-dispatched as a synthetic `Enter` `KeyboardInput` through the existing `FocusedInput` dispatch machinery. Every screen (button/checkbox/radio/slider) already reacts to Enter/Space via `bevy_ui_widgets`, so this needed **zero per-screen changes**.
- **In-game**: left stick drives MoveForward/Backward/StrafeLeft/Right, right stick drives CameraYaw/Pitch, bumpers zoom - by holding/releasing whatever `KeyCode` is currently bound to each `ffxi_viewer_core::Action` (respecting rebinding), exactly as if that key were physically held. `input::handle_input_system`/`dispatch_movement_system` needed no changes.
- **On-screen keyboard**: the primary window now sets `ime_enabled: true` so gamescope can show the Deck's on-screen keyboard when a text field gains focus (was off by default, so it could never appear).

Deliberately scoped to navigation/movement/camera only. Combat/menu action buttons (ToggleEngage, OpenMenu, NavConfirm) are left for a follow-up since they need HUD/menu-state context to avoid a single button press both confirming a menu and firing a combat action.

This branch is stacked on #117 (the Linux CXXFLAGS build fix) since the gamepad code can't be built/tested on Linux without it.

## Test plan

- [x] `cargo build -p ffxi-client --features native-window` on native Linux (Fedora toolbox on a Steam Deck / Bazzite host) - clean build, `cargo fmt --check` and `cargo clippy --no-deps` both pass with no new warnings.
- [x] Ran the built binary: launcher UI renders, no panics, gamepad (Steam Deck controller + Xbox pad) detected as before.
- [ ] Physical D-pad/South-button navigation through login -> char-select and in-world stick movement/camera - queued for hands-on verification on the Deck itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)