### PR TITLE
fix(nav): don't block movement into navmesh coverage gaps

### DIFF
--- a/ffxi-nav-recast/src/lib.rs
+++ b/ffxi-nav-recast/src/lib.rs
@@ -124,6 +124,11 @@ impl RecastNavMesh {
         Some(detour_to_ffxi(snapped).z)
     }
 
+    /// Coverage-check search extent for [`Self::slide_along`]'s off-mesh
+    /// fallback: wide enough to say "there is truly no navmesh data near
+    /// this destination", not just "no directly-connected polygon".
+    const COVERAGE_CHECK_EXT: [f32; 3] = [15.0, 100.0, 15.0];
+
     pub fn slide_along(&self, from: Vec3, to: Vec3) -> Option<Vec3> {
         let filter = DtQueryFilter::default();
         let start = ffxi_to_detour(from);
@@ -142,6 +147,26 @@ impl RecastNavMesh {
             .query
             .move_along_surface(start_ref, &snapped_start, &end, &filter, &mut visited)
             .ok()?;
+
+        // move_along_surface clamps to the connected-polygon boundary
+        // whenever `end` isn't reachable, and that's indistinguishable from
+        // its result alone between "a real wall/edge" and "LSB's xiNavmeshes
+        // bake (built for mob pathing, not full player-walkable coverage)
+        // simply never generated data out here". Treating the latter as a
+        // wall regresses walkable retail space (e.g. decorative plazas mobs
+        // never path through), so: if nothing exists near the *destination*
+        // even under a generous search, there's no data at all — return
+        // None so the caller's off-mesh fallback lets the raw move through
+        // instead of clamping to this edge.
+        let has_nearby_coverage = self
+            .query
+            .find_nearest_poly_1(&end, &Self::COVERAGE_CHECK_EXT, &filter)
+            .ok()
+            .is_some_and(|(poly_ref, _)| !poly_ref.is_null());
+        if !has_nearby_coverage {
+            return None;
+        }
+
         Some(detour_to_ffxi(result_d))
     }
 }


### PR DESCRIPTION
Decomposed from #118 (original commit by @SoraStrifeL, cherry-picked onto current `main`).

Movement was being blocked where the LSB Recast navmesh has coverage gaps; this stops treating a gap as an impassable boundary. Touches only \`ffxi-nav-recast/src/lib.rs\`.

Verified: `cargo check` + `cargo clippy` clean on current main (Bevy 0.19) alongside the other two decomposed slices.

Part of splitting the 52-commit #118 mega-branch into focused, reviewable PRs. #118 as a whole cannot merge — it predates main's Bevy 0.18→0.19 migration and HUD redesign — so its self-contained wins are being peeled off individually.