### PR TITLE
feat(event-vm): implement LOADEXTSCHEDULER opcodes 0x5B/0x66

### DIFF
--- a/ffxi-client/src/view_native/text_input.rs
+++ b/ffxi-client/src/view_native/text_input.rs
@@ -744,6 +744,14 @@ fn handle_world_key(
                     let r = ffxi_viewer_core::hud::action_model::NPC_INTERACT_YALMS;
                     dx * dx + dy * dy + dz * dz <= r * r
                 });
+                tracing::info!(
+                    target_id = id,
+                    entity_found = ent.is_some(),
+                    entity_kind = ?ent.map(|e| e.kind),
+                    is_npc,
+                    in_range,
+                    "confirm-action dispatch"
+                );
                 if is_npc {
                     if let (true, Some(ent)) = (in_range, ent) {
                         let _ = cmd_tx.try_send(AgentCommand::Action {

--- a/ffxi-client/src/view_native/text_input.rs
+++ b/ffxi-client/src/view_native/text_input.rs
@@ -744,14 +744,6 @@ fn handle_world_key(
                     let r = ffxi_viewer_core::hud::action_model::NPC_INTERACT_YALMS;
                     dx * dx + dy * dy + dz * dz <= r * r
                 });
-                tracing::info!(
-                    target_id = id,
-                    entity_found = ent.is_some(),
-                    entity_kind = ?ent.map(|e| e.kind),
-                    is_npc,
-                    in_range,
-                    "confirm-action dispatch"
-                );
                 if is_npc {
                     if let (true, Some(ent)) = (in_range, ent) {
                         let _ = cmd_tx.try_send(AgentCommand::Action {

--- a/ffxi-event/src/opcode_meta.rs
+++ b/ffxi-event/src/opcode_meta.rs
@@ -565,7 +565,12 @@ pub const OPCODE_META: &[OpMeta] = &[
         valid: true,
     }, // 0x005A
     OpMeta {
-        size: 17,
+        // research/XiEvents/OpCodes/0x005B.md:33,144 — dispatched with param3=0,
+        // so every ExecPointer path advances 15 (the +2 is param3-gated and unused
+        // by 0x5B/0x66). atom0s's size table ambiguously lists "15, 17"; the
+        // param3=0 call site is authoritative. Confirm against a captured event
+        // stream if one containing 0x5B/0x66 becomes available.
+        size: 15,
         jumps: false,
         sets_ret: true,
         valid: true,
@@ -631,7 +636,9 @@ pub const OPCODE_META: &[OpMeta] = &[
         valid: true,
     }, // 0x0065
     OpMeta {
-        size: 17,
+        // See 0x005B: 0x0066 dispatches to the same helper with param3=0, so it
+        // advances 15 too (research/XiEvents/OpCodes/0x0066.md:22).
+        size: 15,
         jumps: false,
         sets_ret: true,
         valid: true,

--- a/ffxi-event/src/vm.rs
+++ b/ffxi-event/src/vm.rs
@@ -561,8 +561,8 @@ mod tests {
         for op in [OP_LOADEXTSCHEDULER, OP_LOADEXTSCHEDULER2] {
             let size = OPCODE_META[op as usize].size as usize;
             assert_eq!(
-                size, 17,
-                "op 0x{op:02X} size drifted from research/XiEvents/OpCodes"
+                size, 15,
+                "op 0x{op:02X} size drifted from research/XiEvents/OpCodes (param3=0 advance)"
             );
             let mut data = vec![op];
             data.extend(std::iter::repeat_n(0u8, size - 1));

--- a/ffxi-event/src/vm.rs
+++ b/ffxi-event/src/vm.rs
@@ -66,6 +66,8 @@ const OP_REQSET: u8 = 0x27;
 const OP_REQSET_CHECKED: u8 = 0x28;
 const OP_REQSET_PRIORITY: u8 = 0x29;
 const OP_REQWAIT: u8 = 0x2A;
+const OP_LOADEXTSCHEDULER: u8 = 0x5B;
+const OP_LOADEXTSCHEDULER2: u8 = 0x66;
 const OP_SETBITWORK: u8 = 0x40;
 const OP_GETBITWORK: u8 = 0x41;
 const OP_SENDTAG: u8 = 0x43;
@@ -330,6 +332,13 @@ impl EventVm {
                 OP_REQSET | OP_REQSET_CHECKED | OP_REQSET_PRIORITY | OP_REQWAIT => {
                     self.exec_pointer += OPCODE_META[op as usize].size as usize;
                 }
+                // XiEvent LOADEXTSCHEDULER (research/XiEvents/OpCodes/0x005B.md,
+                // 0x0066.md): plays a motion between two actors, but always
+                // takes the "actor not found" early exit since this dialog-only
+                // VM models no actors.
+                OP_LOADEXTSCHEDULER | OP_LOADEXTSCHEDULER2 => {
+                    self.exec_pointer += OPCODE_META[op as usize].size as usize;
+                }
                 _ => {
                     let meta = OPCODE_META.get(op as usize).copied();
                     match meta {
@@ -532,6 +541,27 @@ mod tests {
         ] {
             assert_eq!(
                 OPCODE_META[op as usize].size as usize, size,
+                "op 0x{op:02X} size drifted from research/XiEvents/OpCodes"
+            );
+            let mut data = vec![op];
+            data.extend(std::iter::repeat_n(0u8, size - 1));
+            data.push(OP_END);
+            let mut e = vm(data, vec![]);
+            assert_eq!(
+                e.step(),
+                StepResult::Done,
+                "op 0x{op:02X} should run to END"
+            );
+            assert_eq!(e.exec_pointer(), size, "op 0x{op:02X} advanced wrong size");
+        }
+    }
+
+    #[test]
+    fn loadextscheduler_family_skips_by_size_and_continues() {
+        for op in [OP_LOADEXTSCHEDULER, OP_LOADEXTSCHEDULER2] {
+            let size = OPCODE_META[op as usize].size as usize;
+            assert_eq!(
+                size, 17,
                 "op 0x{op:02X} size drifted from research/XiEvents/OpCodes"
             );
             let mut data = vec![op];


### PR DESCRIPTION
Decomposed from #118 (original commit by @SoraStrifeL, cherry-picked onto current `main`).

Implements the event-VM \`LOADEXTSCHEDULER\` opcodes (0x5B/0x66). Touches \`ffxi-event/src/vm.rs\` (pure VM logic) and a small dispatch hook in \`text_input.rs\`.

Verified: `cargo check` + `cargo clippy` clean on current main (Bevy 0.19) alongside the other two decomposed slices.

Part of splitting the 52-commit #118 mega-branch into focused, reviewable PRs. #118 as a whole cannot merge — it predates main's Bevy 0.18→0.19 migration and HUD redesign — so its self-contained wins are being peeled off individually.