### PR TITLE
feat(interact): wire door targeting and the Open action (kuluu-dag)

### DIFF
--- a/ffxi-client/src/view_native/text_input.rs
+++ b/ffxi-client/src/view_native/text_input.rs
@@ -1133,6 +1133,30 @@ fn confirm_target_action_at_cursor(
             push_system_chat_line(scene_state, "[menu] Trust — not implemented yet".into());
             Some(InputMode::World)
         }
+        TargetActionId::Open => {
+            match target_ent {
+                Some(e) => {
+                    // Doors are TYPE_NPC server-side (look.size == 0x02) and
+                    // trigger through the same Talk action_id as any other
+                    // NPC — vendor/server/src/map/packets/c2s/0x01a_action.cpp:198,213.
+                    // The server's own door script drives the yes/no confirm
+                    // and zone change; nothing door-specific is needed here.
+                    let cmd = AgentCommand::Action {
+                        target_id: e.id,
+                        target_index: e.act_index,
+                        kind: ActionKind::Talk,
+                    };
+                    if let Err(err) = cmd_tx.try_send(cmd) {
+                        push_system_chat_line(
+                            scene_state,
+                            format!("[menu] Open dispatch dropped: {err}"),
+                        );
+                    }
+                }
+                None => push_system_chat_line(scene_state, "[menu] Open: no target".to_string()),
+            }
+            Some(InputMode::World)
+        }
     }
 }
 

--- a/ffxi-viewer-core/src/hud/action_model.rs
+++ b/ffxi-viewer-core/src/hud/action_model.rs
@@ -14,6 +14,7 @@ pub enum TargetActionId {
     Trade,
     Disengage,
     Check,
+    Open,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -116,6 +117,8 @@ fn applies_to(id: TargetActionId, kind: TargetKindLite, engaged: bool) -> bool {
         TargetActionId::Items => matches!(kind, None | Mob | Pc | SelfPc),
 
         TargetActionId::Trust => matches!(kind, None | Pc | SelfPc),
+
+        TargetActionId::Open => matches!(kind, Door),
     }
 }
 
@@ -126,6 +129,7 @@ pub fn build_target_action_entries(
     const ORDER: &[TargetActionId] = &[
         TargetActionId::SwitchTarget,
         TargetActionId::Attack,
+        TargetActionId::Open,
         TargetActionId::Chat,
         TargetActionId::Magic,
         TargetActionId::Abilities,
@@ -145,7 +149,10 @@ pub fn build_target_action_entries(
             continue;
         }
 
-        let needs_range = matches!(id, TargetActionId::Chat | TargetActionId::Trade);
+        let needs_range = matches!(
+            id,
+            TargetActionId::Chat | TargetActionId::Trade | TargetActionId::Open
+        );
         let out_of_range = needs_range && ctx.has_target && !ctx.in_range;
         // Retail greys the Command Menu "Items" entry when nothing in the
         // bags would pass the 0x037 use gate (kuluu-268h).
@@ -180,6 +187,7 @@ pub fn build_target_action_entries(
             TargetActionId::Items => (ActionEntryKind::Plain, "Items".to_string()),
             TargetActionId::Trade => (ActionEntryKind::Plain, "Trade".to_string()),
             TargetActionId::Check => (ActionEntryKind::Plain, "Check".to_string()),
+            TargetActionId::Open => (ActionEntryKind::Plain, "Open".to_string()),
         };
 
         let hint = if out_of_range {
@@ -214,12 +222,16 @@ pub fn context_for_target(
     let ent = target_id.and_then(|id| entities.iter().find(|e| e.id == id));
     let (target_kind, in_range) = match ent {
         Some(e) => {
-            let kind = match e.kind {
-                EntityKind::Pc if Some(e.id) == self_id => TargetKindLite::SelfPc,
-                EntityKind::Pc => TargetKindLite::Pc,
-                EntityKind::Npc => TargetKindLite::Npc,
-                EntityKind::Mob => TargetKindLite::Mob,
-                EntityKind::Pet | EntityKind::Other => TargetKindLite::None,
+            let kind = if matches!(e.look, Some(ffxi_viewer_wire::EntityLook::Door { .. })) {
+                TargetKindLite::Door
+            } else {
+                match e.kind {
+                    EntityKind::Pc if Some(e.id) == self_id => TargetKindLite::SelfPc,
+                    EntityKind::Pc => TargetKindLite::Pc,
+                    EntityKind::Npc => TargetKindLite::Npc,
+                    EntityKind::Mob => TargetKindLite::Mob,
+                    EntityKind::Pet | EntityKind::Other => TargetKindLite::None,
+                }
             };
             let dx = e.pos.x - self_pos.x;
             let dy = e.pos.y - self_pos.y;

--- a/ffxi-viewer-core/src/hud/overlay.rs
+++ b/ffxi-viewer-core/src/hud/overlay.rs
@@ -23,6 +23,7 @@ pub enum MenuEntryId {
     TargetTrade,
     TargetDisengage,
     TargetCheck,
+    TargetOpen,
 }
 
 impl MenuEntryId {
@@ -38,6 +39,7 @@ impl MenuEntryId {
             TargetActionId::Trade => MenuEntryId::TargetTrade,
             TargetActionId::Disengage => MenuEntryId::TargetDisengage,
             TargetActionId::Check => MenuEntryId::TargetCheck,
+            TargetActionId::Open => MenuEntryId::TargetOpen,
         }
     }
 }


### PR DESCRIPTION
Decomposed from #118 (original commit by @SoraStrifeL, cherry-picked onto current `main`).

Wires door targeting and the Open action into the target-action menu. Touches \`hud/action_model.rs\`, \`hud/overlay.rs\`, and \`text_input.rs\`.

Verified: `cargo check` + `cargo clippy` clean on current main (Bevy 0.19) alongside the other two decomposed slices.

Part of splitting the 52-commit #118 mega-branch into focused, reviewable PRs. #118 as a whole cannot merge — it predates main's Bevy 0.18→0.19 migration and HUD redesign — so its self-contained wins are being peeled off individually.